### PR TITLE
Ratel: allow optinally disabling Ratel. Enabled by default.

### DIFF
--- a/charts/dgraph/templates/ratel-deployment.yaml
+++ b/charts/dgraph/templates/ratel-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ratel.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -63,3 +64,4 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.ratel.resources | indent 10 }}
+{{- end }}

--- a/charts/dgraph/templates/ratel-svc.yaml
+++ b/charts/dgraph/templates/ratel-svc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ratel.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -19,3 +20,4 @@ spec:
     chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.ratel.name }}
     release: {{ .Release.Name }}
+{{- end }}

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -244,6 +244,7 @@ alpha:
     successThreshold: 1
 
 ratel:
+  enabled: true
   name: ratel
   ## Number of dgraph nodes
   ##


### PR DESCRIPTION
Adds new ratel.enabled field in the values.yaml, set to true by default.
By setting it false, both ratel-deployment.yaml and ratel-sac.yaml files get omitted.

Having this flag enables users to launch Dgraph alpha and zero servers but not Ratel.

Tested it locally with both true and false values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/20)
<!-- Reviewable:end -->
