### PR TITLE
DGRAPH-1564 User Specified Ports for Zero, Alpha, Ratel

### DIFF
--- a/charts/dgraph/templates/alpha-statefulset.yaml
+++ b/charts/dgraph/templates/alpha-statefulset.yaml
@@ -97,6 +97,10 @@ spec:
           name: alpha-grpc
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         env:
+        {{- range $key, $value := .Values.alpha.envvars }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+        {{- end }}
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:

--- a/charts/dgraph/templates/alpha-statefulset.yaml
+++ b/charts/dgraph/templates/alpha-statefulset.yaml
@@ -97,7 +97,7 @@ spec:
           name: alpha-grpc
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         env:
-        {{- range $key, $value := .Values.alpha.envvars }}
+        {{- range $key, $value := .Values.alpha.extraEnvs }}
           - name: {{ $key }}
             value: {{ $value | quote }}
         {{- end }}

--- a/charts/dgraph/templates/alpha-statefulset.yaml
+++ b/charts/dgraph/templates/alpha-statefulset.yaml
@@ -96,15 +96,14 @@ spec:
         - containerPort: 9080
           name: alpha-grpc
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-        env:
-        {{- range $key, $value := .Values.alpha.extraEnvs }}
-          - name: {{ $key }}
-            value: {{ $value | quote }}
-        {{- end }}
+        env:   
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+        {{- with .Values.alpha.extraEnvs }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         command:
          - bash
          - "-c"

--- a/charts/dgraph/templates/ratel-deployment.yaml
+++ b/charts/dgraph/templates/ratel-deployment.yaml
@@ -34,6 +34,12 @@ spec:
       - name: "{{ template "dgraph.ratel.fullname" . }}"
         image: "{{ template "dgraph.image" . }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+        {{- if .Values.ratel.extraEnvs }}
+        env:
+        {{- with .Values.ratel.extraEnvs }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- end }}
         command:
           - dgraph-ratel
         ports:

--- a/charts/dgraph/templates/zero-statefulset.yaml
+++ b/charts/dgraph/templates/zero-statefulset.yaml
@@ -99,6 +99,9 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+        {{- with .Values.zero.extraEnvs }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         command:
          - bash
          - "-c"

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -101,7 +101,7 @@ zero:
 
   ## Node labels and tolerations for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   ##
   nodeSelector: {}
   tolerations: []
@@ -176,6 +176,11 @@ alpha:
   ## https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
   nodeAffinity: {}
 
+  # This will environment variables.
+  envvars:
+    # AWS_ACCESS_KEY_ID: XXXXXXXXXXXXXXXXXXXX
+    # AWS_SECRET_ACCESS_KEY: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
   ## Kubernetes configuration
   ## For minikube, set this to NodePort, elsewhere use LoadBalancer
   ##
@@ -205,7 +210,7 @@ alpha:
 
   ## Node labels and tolerations for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   ##
   nodeSelector: {}
   tolerations: []

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -178,8 +178,10 @@ alpha:
 
   # Extra environment variables which will be appendend to the env: definition for the container.
   extraEnvs:
-    # AWS_ACCESS_KEY_ID: XXXXXXXXXXXXXXXXXXXX
-    # AWS_SECRET_ACCESS_KEY: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    # - name: AWS_ACCESS_KEY_ID
+    #   value: "XXXXXXXXXXXXXXXXXXXX"
+    # - name: AWS_SECRET_ACCESS_KEY
+    #   value: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
   ## Kubernetes configuration
   ## For minikube, set this to NodePort, elsewhere use LoadBalancer

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -176,8 +176,8 @@ alpha:
   ## https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
   nodeAffinity: {}
 
-  # This will environment variables.
-  envvars:
+  # Extra environment variables which will be appendend to the env: definition for the container.
+  extraEnvs:
     # AWS_ACCESS_KEY_ID: XXXXXXXXXXXXXXXXXXXX
     # AWS_SECRET_ACCESS_KEY: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -73,7 +73,7 @@ zero:
   ## https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
   nodeAffinity: {}
 
-  # Extra environment variables which will be appendend to the env: definition for the container.
+  # Extra environment variables which will be appended to the env: definition for the container.
   extraEnvs: []
 
   ## Kubernetes configuration
@@ -179,8 +179,8 @@ alpha:
   ## https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
   nodeAffinity: {}
 
-  # Extra environment variables which will be appendend to the env: definition for the container.
-  extraEnvs:
+  # Extra environment variables which will be appended to the env: definition for the container.
+  extraEnvs: []
     # - name: AWS_ACCESS_KEY_ID
     #   value: "XXXXXXXXXXXXXXXXXXXX"
     # - name: AWS_SECRET_ACCESS_KEY
@@ -259,7 +259,7 @@ ratel:
   ##
   replicaCount: 1
 
-  # Extra environment variables which will be appendend to the env: definition for the container.
+  # Extra environment variables which will be appended to the env: definition for the container.
   extraEnvs: []
 
   ## Kubernetes configuration

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -73,6 +73,9 @@ zero:
   ## https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
   nodeAffinity: {}
 
+  # Extra environment variables which will be appendend to the env: definition for the container.
+  extraEnvs: []
+
   ## Kubernetes configuration
   ## For minikube, set this to NodePort, elsewhere use LoadBalancer
   ##

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -259,6 +259,9 @@ ratel:
   ##
   replicaCount: 1
 
+  # Extra environment variables which will be appendend to the env: definition for the container.
+  extraEnvs: []
+
   ## Kubernetes configuration
   ## For minikube, set this to NodePort, elsewhere use ClusterIP or LoadBalancer
   ##


### PR DESCRIPTION
Adding support for user specified environment variables for zero, alpha, ratel.

## Changes

* Add extraEnvs option in values.yaml under ratel, zero, and alpha
* Update documentation links

## Example

Example of ysing this in `values.yaml`

```yaml
alpha
  extraEnvs:
    - name: AWS_ACCESS_KEY_ID
      value: "XXXXXXXXXXXXXXXXXXXX"
    - name: AWS_SECRET_ACCESS_KEY
      value: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
```

## Testing

You can test out the values before deploying with:

```bash
git clone git@github.com:dgraph-io/charts.git
# make changes for extraEnvs charts/charts/dgraph/values.yaml
helm install --dry-run --debug --generate-name charts/charts/dgraph/
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/22)
<!-- Reviewable:end -->
