### PR TITLE
Ingress Support

### DIFF
--- a/charts/dgraph/example_values/ingress-alb.yaml
+++ b/charts/dgraph/example_values/ingress-alb.yaml
@@ -1,0 +1,17 @@
+# aws-alb-ingress-controller
+# * https://kubernetes-sigs.github.io/aws-alb-ingress-controller
+global:
+  ingress:
+    enabled: true
+    ratel_hostname: ratel.example.com
+    alpha_hostname: alpha.example.com
+    annotations:
+      kubernetes.io/ingress.class: alb
+      # ip for ClusterIP, instance for NodePort
+      alb.ingress.kubernetes.io/target-type: ip
+      # internet-facing or internal
+      alb.ingress.kubernetes.io/scheme: internet-facing
+      # terminate TLS using ACM (https://aws.amazon.com/certificate-manager/)
+      alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:012345678901:certificate/01234567-0123-0123-0123-0123456789ab
+      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
+      alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'

--- a/charts/dgraph/example_values/ingress-gce.yaml
+++ b/charts/dgraph/example_values/ingress-gce.yaml
@@ -1,0 +1,21 @@
+# GKE Default Ingress
+# * https://cloud.google.com/kubernetes-engine/docs/concepts/ingress
+alpha:
+  ingress:
+    enabled: true
+    hostname: alpha.example.com
+    annotations:
+      kubernetes.io/ingress.class: gce
+  # NodePort or LoadBalancer required for GCE ingress
+  service:
+    type: NodePort
+
+ratel:
+  ingress:
+    enabled: true
+    hostname: ratel.example.com
+    annotations:
+      kubernetes.io/ingress.class: gce
+  # NodePort or LoadBalancer required for GCE ingress
+  service:
+    type: NodePort

--- a/charts/dgraph/example_values/ingress-nginx.yaml
+++ b/charts/dgraph/example_values/ingress-nginx.yaml
@@ -1,0 +1,17 @@
+# ingress-nginx with certificate manager
+# * https://cert-manager.io/
+# * https://kubernetes.github.io/ingress-nginx/
+global:
+  ingress:
+    enabled: false
+    anotations:
+      kubernetes.io/ingress.class: nginx
+      nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      cert-manager.io/cluster-issuer: letsencrypt-staging
+    tls:
+    - hosts:
+      - ratel.example.com
+      - alpha.example.com
+      secretName: example-tls
+    ratel_hostname: ratel.example.com
+    alpha_hostname: alpha.example.com

--- a/charts/dgraph/templates/alpha-ingress.yaml
+++ b/charts/dgraph/templates/alpha-ingress.yaml
@@ -40,4 +40,19 @@ spec:
             backend:
               serviceName: {{ template "dgraph.alpha.fullname" . }}
               servicePort: 8080
+    - host: {{ .Values.alpha.ingress.grpc_hostname }}
+      http:
+        paths:
+          {{- if index $.Values.alpha.ingress "annotations" }}
+          {{- if eq (index $.Values.alpha.ingress.annotations "kubernetes.io/ingress.class" | default "") "gce" "alb" "nsx" }}
+          - path: /*
+          {{- else }}{{/* Has annotations but ingress class is not "gce" nor "alb" */}}
+          - path: /
+          {{- end }}
+          {{- else}}{{/* Has no annotations */}}
+          - path: /
+          {{- end }}
+            backend:
+              serviceName: {{ template "dgraph.alpha.fullname" . }}
+              servicePort: 9080
 {{- end }}

--- a/charts/dgraph/templates/alpha-ingress.yaml
+++ b/charts/dgraph/templates/alpha-ingress.yaml
@@ -40,19 +40,4 @@ spec:
             backend:
               serviceName: {{ template "dgraph.alpha.fullname" . }}
               servicePort: 8080
-    - host: {{ .Values.alpha.ingress.grpc_hostname }}
-      http:
-        paths:
-          {{- if index $.Values.alpha.ingress "annotations" }}
-          {{- if eq (index $.Values.alpha.ingress.annotations "kubernetes.io/ingress.class" | default "") "gce" "alb" "nsx" }}
-          - path: /*
-          {{- else }}{{/* Has annotations but ingress class is not "gce" nor "alb" */}}
-          - path: /
-          {{- end }}
-          {{- else}}{{/* Has no annotations */}}
-          - path: /
-          {{- end }}
-            backend:
-              serviceName: {{ template "dgraph.alpha.fullname" . }}
-              servicePort: 9080
 {{- end }}

--- a/charts/dgraph/templates/alpha-ingress.yaml
+++ b/charts/dgraph/templates/alpha-ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "dgraph.alpha.fullname" . }}
+  name: {{ template "dgraph.alpha.fullname" . }}-ingress
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/alpha-ingress.yaml
+++ b/charts/dgraph/templates/alpha-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.alpha.ingress.enabled -}}
+{{- if and (eq .Values.alpha.ingress.enabled true) (eq .Values.global.ingress.enabled false) -}}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
@@ -28,7 +28,15 @@ spec:
     - host: {{ .Values.alpha.ingress.hostname }}
       http:
         paths:
+          {{- if index $.Values.alpha.ingress "annotations" }}
+          {{- if eq (index $.Values.alpha.ingress.annotations "kubernetes.io/ingress.class" | default "") "gce" "alb" "nsx" }}
+          - path: /*
+          {{- else }}{{/* Has annotations but ingress class is not "gce" nor "alb" */}}
           - path: /
+          {{- end }}
+          {{- else}}{{/* Has no annotations */}}
+          - path: /
+          {{- end }}
             backend:
               serviceName: {{ template "dgraph.alpha.fullname" . }}
               servicePort: 8080

--- a/charts/dgraph/templates/alpha-ingress.yaml
+++ b/charts/dgraph/templates/alpha-ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.alpha.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "dgraph.alpha.fullname" . }}
+  labels:
+    app: {{ template "dgraph.name" . }}
+    chart: {{ template "dgraph.chart" . }}
+    component: {{ .Values.alpha.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- with .Values.alpha.ingress.annotations }}
+  annotations:
+    {{- toYaml . | trimSuffix "\n" | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.alpha.ingress.tls }}
+  tls:
+  {{- range .Values.alpha.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+    - host: {{ .Values.alpha.ingress.hostname }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ template "dgraph.alpha.fullname" . }}
+              servicePort: 8080
+{{- end }}

--- a/charts/dgraph/templates/global-ingress.yaml
+++ b/charts/dgraph/templates/global-ingress.yaml
@@ -1,0 +1,58 @@
+{{- if (eq .Values.global.ingress.enabled true) -}}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "dgraph.fullname" . }}-ingress
+  labels:
+    app: {{ template "dgraph.name" . }}
+    chart: {{ template "dgraph.chart" . }}
+    component: {{ .Values.alpha.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- with .Values.global.ingress.annotations }}
+  annotations:
+    {{- toYaml . | trimSuffix "\n" | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.global.ingress.tls }}
+  tls:
+  {{- range .Values.global.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+    - host: {{ .Values.global.ingress.alpha_hostname }}
+      http:
+        paths:
+          {{- if index $.Values.global.ingress "annotations" }}
+          {{- if eq (index $.Values.global.ingress.annotations "kubernetes.io/ingress.class" | default "") "gce" "alb" "nsx" }}
+          - path: /*
+          {{- else }}{{/* Has annotations but ingress class is not "gce" nor "alb" */}}
+          - path: /
+          {{- end }}
+          {{- else}}{{/* Has no annotations */}}
+          - path: /
+          {{- end }}
+            backend:
+              serviceName: {{ template "dgraph.alpha.fullname" . }}
+              servicePort: 8080
+    - host: {{ .Values.global.ingress.ratel_hostname }}
+      http:
+        paths:
+          {{- if index $.Values.global.ingress "annotations" }}
+          {{- if eq (index $.Values.global.ingress.annotations "kubernetes.io/ingress.class" | default "") "gce" "alb" "nsx" }}
+          - path: /*
+          {{- else }}{{/* Has annotations but ingress class is not "gce" nor "alb" */}}
+          - path: /
+          {{- end }}
+          {{- else}}{{/* Has no annotations */}}
+          - path: /
+          {{- end }}
+            backend:
+              serviceName: {{ template "dgraph.alpha.fullname" . }}
+              servicePort: 8000
+{{- end }}

--- a/charts/dgraph/templates/ratel-ingress.yaml
+++ b/charts/dgraph/templates/ratel-ingress.yaml
@@ -3,7 +3,7 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "dgraph.ratel.fullname" . }}
+  name: {{ template "dgraph.ratel.fullname" . }}-ingress
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/ratel-ingress.yaml
+++ b/charts/dgraph/templates/ratel-ingress.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.ratel.ingress.enabled -}}
+{{- if and (eq .Values.ratel.ingress.enabled true) (eq .Values.global.ingress.enabled false) -}}
+
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
@@ -28,7 +29,15 @@ spec:
     - host: {{ .Values.ratel.ingress.hostname }}
       http:
         paths:
+          {{- if index $.Values.ratel.ingress "annotations" }}
+          {{- if eq (index $.Values.ratel.ingress.annotations "kubernetes.io/ingress.class" | default "") "gce" "alb" "nsx" }}
+          - path: /*
+          {{- else }}{{/* Has annotations but ingress class is not "gce" nor "alb" */}}
           - path: /
+          {{- end }}
+          {{- else}}{{/* Has no annotations */}}
+          - path: /
+          {{- end }}
             backend:
               serviceName: {{ template "dgraph.ratel.fullname" . }}
               servicePort: 8000

--- a/charts/dgraph/templates/ratel-ingress.yaml
+++ b/charts/dgraph/templates/ratel-ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ratel.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "dgraph.ratel.fullname" . }}
+  labels:
+    app: {{ template "dgraph.name" . }}
+    chart: {{ template "dgraph.chart" . }}
+    component: {{ .Values.ratel.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- with .Values.ratel.ingress.annotations }}
+  annotations:
+    {{- toYaml . | trimSuffix "\n" | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ratel.ingress.tls }}
+  tls:
+  {{- range .Values.ratel.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+    - host: {{ .Values.ratel.ingress.hostname }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ template "dgraph.ratel.fullname" . }}
+              servicePort: 8000
+{{- end }}

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -182,6 +182,12 @@ alpha:
   service:
     type: ClusterIP
 
+  ## Kubernetes ingress configuration
+  ## This requires an ingress controller to be installed into your cluster
+  ingress:
+    enabled: false
+    # hostname: alpha.mycompany.com
+
   ## dgraph Pod Security Context
   securityContext:
     enabled: false
@@ -254,6 +260,12 @@ ratel:
   ##
   service:
     type: ClusterIP
+
+  ## Kubernetes ingress configuration
+  ## This requires an ingress controller to be installed into your cluster
+  ingress:
+    enabled: false
+    # hostname: ratel.mycompany.com
 
   ## dgraph Pod Security Context
   securityContext:

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -333,3 +333,12 @@ ratel:
     timeoutSeconds: 5
     failureThreshold: 6
     successThreshold: 1
+
+
+global:
+  # This ingress override existing ingress configurations for alpha, ratel, zero
+  ingress:
+    enabled: false
+    annotations: {}
+    tls: {}
+    rules: {}

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -182,26 +182,13 @@ alpha:
   service:
     type: ClusterIP
 
-  ## Kubernetes ingress configuration
-  ## This requires an ingress controller to be installed into your cluster
+  ## alpha ingress respirce configuration
+  ## This requires an ingress controller to be installed into your k8s cluster
   ingress:
     enabled: false
-    # hostname: alpha.mycompany.com
-    #
-    # Example Annotation for ingress-nginx
-    # annotations:
-    #   kubernetes.io/ingress.class: nginx
-    #
-    # Example Annotations for aws-alb-ingress-controller
-    # annotations:
-    #   kubernetes.io/ingress.class: alb
-    #   # target-type: ip = ClusterIP, instance = NodePort
-    #   alb.ingress.kubernetes.io/target-type: ip
-    #   # scheme: 'internet-facing' or 'internal'
-    #   alb.ingress.kubernetes.io/scheme: internet-facing
-    #   alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:012345678901:certificate/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-    #   alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
-    #   alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+    # hostname: ""
+    # annoations: {}
+    # tls: {}
 
   ## dgraph Pod Security Context
   securityContext:
@@ -276,26 +263,13 @@ ratel:
   service:
     type: ClusterIP
 
-  ## Kubernetes ingress configuration
-  ## This requires an ingress controller to be installed into your cluster
+  ## ratel ingress respirce configuration
+  ## This requires an ingress controller to be installed into your k8s cluster
   ingress:
     enabled: false
-    # hostname: ratel.mycompany.com
-    #
-    # Example Annotation for ingress-nginx
-    # annotations:
-    #   kubernetes.io/ingress.class: nginx
-    #
-    # Example Annotations for aws-alb-ingress-controller
-    # annotations:
-    #   kubernetes.io/ingress.class: alb
-    #   # target-type: ip = ClusterIP, instance = NodePort
-    #   alb.ingress.kubernetes.io/target-type: ip
-    #   # scheme: 'internet-facing' or 'internal'
-    #   alb.ingress.kubernetes.io/scheme: internet-facing
-    #   alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:012345678901:certificate/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-    #   alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
-    #   alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+    # hostname: ""
+    # annoations: {}
+    # tls: {}
 
   ## dgraph Pod Security Context
   securityContext:
@@ -336,9 +310,13 @@ ratel:
 
 
 global:
-  # This ingress override existing ingress configurations for alpha, ratel, zero
+  ## Combined ingress resource for alpha and ratel services
+  ## This will override existing ingress configurations under alpha and ratel
+  ## This requires an ingress controller to be installed into your k8s cluster
+
   ingress:
     enabled: false
     annotations: {}
     tls: {}
-    rules: {}
+    ratel_hostname: ""
+    alpha_hostname: ""

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -187,6 +187,21 @@ alpha:
   ingress:
     enabled: false
     # hostname: alpha.mycompany.com
+    #
+    # Example Annotation for ingress-nginx
+    # annotations:
+    #   kubernetes.io/ingress.class: nginx
+    #
+    # Example Annotations for aws-alb-ingress-controller
+    # annotations:
+    #   kubernetes.io/ingress.class: alb
+    #   # target-type: ip = ClusterIP, instance = NodePort
+    #   alb.ingress.kubernetes.io/target-type: ip
+    #   # scheme: 'internet-facing' or 'internal'
+    #   alb.ingress.kubernetes.io/scheme: internet-facing
+    #   alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:012345678901:certificate/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    #   alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
+    #   alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
 
   ## dgraph Pod Security Context
   securityContext:
@@ -266,6 +281,21 @@ ratel:
   ingress:
     enabled: false
     # hostname: ratel.mycompany.com
+    #
+    # Example Annotation for ingress-nginx
+    # annotations:
+    #   kubernetes.io/ingress.class: nginx
+    #
+    # Example Annotations for aws-alb-ingress-controller
+    # annotations:
+    #   kubernetes.io/ingress.class: alb
+    #   # target-type: ip = ClusterIP, instance = NodePort
+    #   alb.ingress.kubernetes.io/target-type: ip
+    #   # scheme: 'internet-facing' or 'internal'
+    #   alb.ingress.kubernetes.io/scheme: internet-facing
+    #   alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-2:012345678901:certificate/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    #   alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
+    #   alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
 
   ## dgraph Pod Security Context
   securityContext:


### PR DESCRIPTION
**Problem**:  
Currently there is no existing way for users to expose an endpoint for ratel or alpha.

**Solution** 
This allows the user to specify two optional endpoints using an Ingress.

**Features**

- Separate Ratel and Alpha Ingress: users can configure/secure the endpoint uniquely with unique annotations and tls configuration per service.
- Global Ingress for ratel and alpha supported: as an alternative, users can use a single ingress and configure them for both services at once
- Examples Directory demonstrating how to use `ingress-nginx` (GKE or EKS), `aws-alb-ingress-controller` (EKS only) and default GKE ingress (`gce`)