### PR TITLE
ratel update to optional disable ratel

### DIFF
--- a/charts/dgraph/templates/ratel-deployment.yaml
+++ b/charts/dgraph/templates/ratel-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if (eq .Values.ratel.enabled true) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -69,3 +70,5 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.ratel.resources | indent 10 }}
+
+{{- end }}

--- a/charts/dgraph/templates/ratel-svc.yaml
+++ b/charts/dgraph/templates/ratel-svc.yaml
@@ -1,3 +1,4 @@
+{{- if (eq .Values.ratel.enabled true) -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -11,7 +12,7 @@ metadata:
 spec:
   type: {{ .Values.ratel.service.type }}
   ports:
-  - port: 8000
+  - port: 80
     targetPort: 8000
     name: ratel-http
   selector:
@@ -19,3 +20,5 @@ spec:
     chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.ratel.name }}
     release: {{ .Release.Name }}
+
+{{- end }}

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -256,7 +256,7 @@ alpha:
 ratel:
   name: ratel
 
-  ## Enable Ratel service?
+  ## Enable Ratel service
   enabled: true
 
   ## Number of dgraph nodes

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -255,6 +255,10 @@ alpha:
 
 ratel:
   name: ratel
+
+  ## Enable Ratel service?
+  enabled: true
+
   ## Number of dgraph nodes
   ##
   replicaCount: 1


### PR DESCRIPTION
## Description
Added functionality to disable installing ratel (default is enabled).  Setting `ratel.enabled` to `false` will disable the service and deployment.

Service also changed to `80` from `8000`.  Backend port from  docker container is still port `8000`.

## Testing

```bash
$ helm install dgraph-ratel-enabled ./charts/charts/dgraph/ --set ratel.enabled=true
$ kubectl get deployment | grep dgraph-ratel-enabled
dgraph-ratel-enabled-dgr-ratel                           1/1     1            1           75s
$ kubectl get svc | grep dgraph-ratel-enabled
dgraph-ratel-enabled-dgr-alpha                      ClusterIP      10.100.234.218   <none>                                                                    8080/TCP,9080/TCP               56s
dgraph-ratel-enabled-dgr-alpha-headless             ClusterIP      None             <none>                                                                    7080/TCP                        56s
dgraph-ratel-enabled-dgr-ratel                      ClusterIP      10.100.107.179   <none>                                                                    80/TCP                          56s
dgraph-ratel-enabled-dgr-zero                       ClusterIP      10.100.75.221    <none>                                                                    5080/TCP,6080/TCP               56s
dgraph-ratel-enabled-dgr-zero-headless              ClusterIP      None             <none>                                                                    5080/TCP                        56s
```

```bash
$ helm install dgraph-ratel-enabled ./charts/charts/dgraph/ --set ratel.enabled=false
$ kubectl get deployment | grep dgraph-ratel-disabled
$ kubectl get svc | grep dgraph-ratel-disabled
dgraph-ratel-disabled-dg-alpha                      ClusterIP      10.100.9.25      <none>                                                                    8080/TCP,9080/TCP               74s
dgraph-ratel-disabled-dg-alpha-headless             ClusterIP      None             <none>                                                                    7080/TCP                        74s
dgraph-ratel-disabled-dg-zero                       ClusterIP      10.100.117.107   <none>                                                                    5080/TCP,6080/TCP               74s
dgraph-ratel-disabled-dg-zero-headless              ClusterIP      None             <none>                                                                    5080/TCP                        74s
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/26)
<!-- Reviewable:end -->
