### PR TITLE
Support for Service Annotations

### DIFF
--- a/charts/dgraph/templates/alpha-svc.yaml
+++ b/charts/dgraph/templates/alpha-svc.yaml
@@ -9,6 +9,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     monitor: {{ .Values.alpha.monitorLabel }}
+  {{- with .Values.alpha.service.annotations }}
+  annotations:
+    {{- toYaml . | trimSuffix "\n" | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.alpha.service.type }}
   ports:

--- a/charts/dgraph/templates/ratel-svc.yaml
+++ b/charts/dgraph/templates/ratel-svc.yaml
@@ -8,6 +8,10 @@ metadata:
     component: {{ .Values.ratel.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.ratel.service.annotations }}
+  annotations:
+    {{- toYaml . | trimSuffix "\n" | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.ratel.service.type }}
   ports:

--- a/charts/dgraph/templates/zero-svc.yaml
+++ b/charts/dgraph/templates/zero-svc.yaml
@@ -9,6 +9,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     monitor: {{ .Values.zero.monitorLabel }}
+  {{- with .Values.zero.service.annotations }}
+  annotations:
+    {{- toYaml . | trimSuffix "\n" | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.zero.service.type }}
   ports:

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -81,6 +81,7 @@ zero:
   ##
   service:
     type: ClusterIP
+    annotations: {}
 
   ## dgraph Pod Security Context
   securityContext:
@@ -191,6 +192,7 @@ alpha:
   ##
   service:
     type: ClusterIP
+    annotations: {}
 
   ## dgraph Pod Security Context
   securityContext:
@@ -267,6 +269,7 @@ ratel:
   ##
   service:
     type: ClusterIP
+    annotations: {}
 
   ## dgraph Pod Security Context
   securityContext:


### PR DESCRIPTION
This adds support for user specified annotations.  This is required for features like:

* TLS certificate termination with AWS ELB
* ExternalDNS registration, e.g. AWS Route53, GoogleCloud CloudDNS
* Service Meshes, e.g. Itsio, Linkerd
* Configure LoadBalancer to be internal private network only

Testing:

1. Testing without `alpha.service.annotations` key
2. Testing default with `alpha.service.annotations` with empty set `{}`
3. Testing with annotation value set, e.g.
    ```bash
    helm install debug --debug --dry-run ./charts/charts/dgraph/ -f values.yaml
    ```
    ```yaml
   alpha:
     name: alpha
     service:
       type: LoadBalancer
       annotations:
         service.beta.kubernetes.io/aws-load-balancer-internal: "true"
   ```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/27)
<!-- Reviewable:end -->
