### PR TITLE
Ingress Update Fix for Ratel Compatibility

### DIFF
--- a/charts/dgraph/Chart.yaml
+++ b/charts/dgraph/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dgraph
-version: 0.0.4
+version: 0.0.5
 appVersion: v1.2.2
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:

--- a/charts/dgraph/templates/global-ingress.yaml
+++ b/charts/dgraph/templates/global-ingress.yaml
@@ -54,5 +54,5 @@ spec:
           {{- end }}
             backend:
               serviceName: {{ template "dgraph.alpha.fullname" . }}
-              servicePort: 8000
+              servicePort: 80
 {{- end }}

--- a/charts/dgraph/templates/global-ingress.yaml
+++ b/charts/dgraph/templates/global-ingress.yaml
@@ -40,6 +40,7 @@ spec:
             backend:
               serviceName: {{ template "dgraph.alpha.fullname" . }}
               servicePort: 8080
+    {{- if .Values.ratel.enabled }}
     - host: {{ .Values.global.ingress.ratel_hostname }}
       http:
         paths:
@@ -55,4 +56,5 @@ spec:
             backend:
               serviceName: {{ template "dgraph.alpha.fullname" . }}
               servicePort: 80
+    {{- end }}
 {{- end }}

--- a/charts/dgraph/templates/ratel-ingress.yaml
+++ b/charts/dgraph/templates/ratel-ingress.yaml
@@ -40,5 +40,5 @@ spec:
           {{- end }}
             backend:
               serviceName: {{ template "dgraph.ratel.fullname" . }}
-              servicePort: 8000
+              servicePort: 80
 {{- end }}

--- a/charts/dgraph/templates/ratel-ingress.yaml
+++ b/charts/dgraph/templates/ratel-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.ratel.ingress.enabled true) (eq .Values.global.ingress.enabled false) -}}
+{{- if and (eq .Values.ratel.ingress.enabled true) (eq .Values.global.ingress.enabled false) (eq .Values.ratel.enabled true) -}}
 
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress


### PR DESCRIPTION
## Description
Ingress needs to be updated to support recent Ratel update.  Specifically:

* ingress needs to use servicePort 80, not 8000 as ratel port was changed
* ingress for ratel service need be disabled if ratel is not enabled

Also

* version bump helm chart

## Testing

This was tested with four helm chart values using:

```bash
helm install test --debug --dry-run ./charts/charts/dgraph/ -f my_values.yaml
```

### Separate Ingresses, Ratel Disabled

```yaml
ratel:
  enabled: false
  ingress:
    enabled: true
    hostname: ratel.example.com
    annotations:
      kubernetes.io/ingress.class: alb
      alb.ingress.kubernetes.io/target-type: ip
      alb.ingress.kubernetes.io/scheme: internet-facing
alpha:
  ingress:
    enabled: true
    hostname: alpha.example.com
    annotations:
      kubernetes.io/ingress.class: alb
      alb.ingress.kubernetes.io/target-type: ip
      alb.ingress.kubernetes.io/scheme: internet-fac
```

### Separate Ingresses, Ratel Enabled

```yaml
ratel:
  enabled: true
  ingress:
    enabled: true
    hostname: ratel.example.com
    annotations:
      kubernetes.io/ingress.class: alb
      alb.ingress.kubernetes.io/target-type: ip
      alb.ingress.kubernetes.io/scheme: internet-facing
alpha:
  ingress:
    enabled: true
    hostname: alpha.example.com
    annotations:
      kubernetes.io/ingress.class: alb
      alb.ingress.kubernetes.io/target-type: ip
      alb.ingress.kubernetes.io/scheme: internet-facing
```

### Global Ingress, Ratel Disabled

```yaml
ratel:
  enabled: false

global:
  ingress:
    enabled: true
    ratel_hostname: ratel.dgraph.io
    alpha_hostname: alpha.dgraph.io
    annotations:
      kubernetes.io/ingress.class: alb
      alb.ingress.kubernetes.io/target-type: ip
      alb.ingress.kubernetes.io/scheme: internet-facing
```

### Global Ingress, Ratel Enabled

```yaml
ratel:
  enabled: true

global:
  ingress:
    enabled: true
    ratel_hostname: ratel.dgraph.io
    alpha_hostname: alpha.dgraph.io
    annotations:
      kubernetes.io/ingress.class: alb
      alb.ingress.kubernetes.io/target-type: ip
      alb.ingress.kubernetes.io/scheme: internet-facing
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/30)
<!-- Reviewable:end -->
