### PR TITLE
custom liveness/readiness probe

### DIFF
--- a/charts/dgraph/Chart.yaml
+++ b/charts/dgraph/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dgraph
-version: 0.0.5
+version: 0.0.6
 appVersion: v1.2.2
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:

--- a/charts/dgraph/templates/alpha-statefulset.yaml
+++ b/charts/dgraph/templates/alpha-statefulset.yaml
@@ -122,6 +122,8 @@ spec:
           timeoutSeconds: {{ .Values.alpha.livenessProbe.timeoutSeconds }}
           successThreshold: {{ .Values.alpha.livenessProbe.successThreshold }}
           failureThreshold: {{ .Values.alpha.livenessProbe.failureThreshold }}
+        {{- else if .Values.alpha.customLivenessProbe }} 
+        livenessProbe: {{- toYaml .Values.alpha.customLivenessProbe | nindent 10 }}
         {{- end }}
         {{- if .Values.alpha.readinessProbe.enabled }}
         readinessProbe:
@@ -133,6 +135,8 @@ spec:
           timeoutSeconds: {{ .Values.alpha.readinessProbe.timeoutSeconds }}
           successThreshold: {{ .Values.alpha.readinessProbe.successThreshold }}
           failureThreshold: {{ .Values.alpha.readinessProbe.failureThreshold }}
+        {{- else if .Values.alpha.customReadinessProbe }} 
+        readinessProbe: {{- toYaml .Values.alpha.customReadinessProbe | nindent 10 }}
         {{- end }}
         volumeMounts:
         {{- if .Values.alpha.persistence.enabled }}

--- a/charts/dgraph/templates/ratel-deployment.yaml
+++ b/charts/dgraph/templates/ratel-deployment.yaml
@@ -56,6 +56,8 @@ spec:
           timeoutSeconds: {{ .Values.ratel.livenessProbe.timeoutSeconds }}
           successThreshold: {{ .Values.ratel.livenessProbe.successThreshold }}
           failureThreshold: {{ .Values.ratel.livenessProbe.failureThreshold }}
+        {{- else if .Values.ratel.customLivenessProbe }}
+        livenessProbe: {{- toYaml .Values.ratel.customLivenessProbe | nindent 10 }}
         {{- end }}
         {{- if .Values.ratel.readinessProbe.enabled }}
         readinessProbe:
@@ -67,6 +69,8 @@ spec:
           timeoutSeconds: {{ .Values.ratel.readinessProbe.timeoutSeconds }}
           successThreshold: {{ .Values.ratel.readinessProbe.successThreshold }}
           failureThreshold: {{ .Values.ratel.readinessProbe.failureThreshold }}
+        {{- else if .Values.ratel.customReadinessProbe }}
+        readinessProbe: {{- toYaml .Values.ratel.customReadinessProbe | nindent 10 }}
         {{- end }}
         resources:
 {{ toYaml .Values.ratel.resources | indent 10 }}

--- a/charts/dgraph/templates/zero-statefulset.yaml
+++ b/charts/dgraph/templates/zero-statefulset.yaml
@@ -127,6 +127,8 @@ spec:
           timeoutSeconds: {{ .Values.zero.livenessProbe.timeoutSeconds }}
           successThreshold: {{ .Values.zero.livenessProbe.successThreshold }}
           failureThreshold: {{ .Values.zero.livenessProbe.failureThreshold }}
+        {{- else if .Values.zero.customLivenessProbe }}
+        livenessProbe: {{- toYaml .Values.zero.customLivenessProbe | nindent 10 }}
         {{- end }}
         {{- if .Values.zero.readinessProbe.enabled }}
         readinessProbe:
@@ -138,6 +140,8 @@ spec:
           timeoutSeconds: {{ .Values.zero.readinessProbe.timeoutSeconds }}
           successThreshold: {{ .Values.zero.readinessProbe.successThreshold }}
           failureThreshold: {{ .Values.zero.readinessProbe.failureThreshold }}
+        {{- else if .Values.zero.customReadinessProbe }}
+        readinessProbe: {{- toYaml .Values.zero.customReadinessProbe | nindent 10 }}
         {{- end }}
         volumeMounts:
         {{- if .Values.zero.persistence.enabled }}

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -140,6 +140,10 @@ zero:
     failureThreshold: 6
     successThreshold: 1
 
+  ## Custom liveness and readiness probes
+  customLivenessProbe: {}
+  customReadinessProbe: {}
+
 alpha:
   name: alpha
   metrics:
@@ -263,6 +267,11 @@ alpha:
     failureThreshold: 6
     successThreshold: 1
 
+  ## Custom liveness and readiness probes
+  customLivenessProbe: {}
+  customReadinessProbe: {}
+
+
 ratel:
   name: ratel
 
@@ -328,6 +337,9 @@ ratel:
     failureThreshold: 6
     successThreshold: 1
 
+  ## Custom liveness and readiness probes
+  customLivenessProbe: {}
+  customReadinessProbe: {}
 
 global:
   ## Combined ingress resource for alpha and ratel services


### PR DESCRIPTION
### Problem

The current health probes (liveness and readiness) only support http.  A customized health, such as cmd.exec, is needed mTLS and service meshes like Itsio.

### Solution

This solution will allow an alternative custom health probes for alpha, zero, ratel.

### Testing 

Tested the following:
* rendering using existing `livenessProbe` and `readinessProbe` (regression)
* rendering using new `customLivenessProbe` and `customReadinessProbe`
* deployed custom version on GKE

Example:

```yaml
ratel:
  customLivenessProbe:
    httpGet:
      port: 8000
      path: /
    initialDelaySeconds: 30
    periodSeconds: 10
    timeoutSeconds: 5
    successThreshold: 1
    failureThreshold: 6
  customReadinessProbe:
    httpGet:
      port: 8000
      path: /
    initialDelaySeconds: 5
    periodSeconds: 10
    timeoutSeconds: 5
    successThreshold: 1
    failureThreshold: 6
  service:
    type: NodePort
  ingress:
    enabled: true
    hostname: ratel.example.com
    annotations:
      kubernetes.io/ingress.class: gce
alpha:
  customLivenessProbe:
    httpGet:
      port: 8080
      path: /health?live=1
    initialDelaySeconds: 15
    periodSeconds: 10
    timeoutSeconds: 5
    successThreshold: 1
    failureThreshold: 6
  customReadinessProbe:
    httpGet:
      port: 8080
      path: /health?live=1
    initialDelaySeconds: 15
    periodSeconds: 10
    timeoutSeconds: 5
    successThreshold: 1
    failureThreshold: 6
  service:
    type: NodePort
  ingress:
    enabled: true
    hostname: alpha.example.com
    annotations:
      kubernetes.io/ingress.class: gce
zero:
  customLivenessProbe:
    httpGet:
      port: 6080
      path: /health
    initialDelaySeconds: 15
    periodSeconds: 10
    timeoutSeconds: 5
    successThreshold: 1
    failureThreshold: 6
  customReadinessProbe:
    httpGet:
      port: 6080
      path: /health
    initialDelaySeconds: 15
    periodSeconds: 10
    timeoutSeconds: 5
    successThreshold: 1
    failureThreshold: 6

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/31)
<!-- Reviewable:end -->
