### PR TITLE
Bug Fixes for readinessProbe

### DIFF
--- a/charts/dgraph/Chart.yaml
+++ b/charts/dgraph/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dgraph
-version: 0.0.5
+version: 0.0.6
 appVersion: v1.2.2
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:

--- a/charts/dgraph/templates/alpha-statefulset.yaml
+++ b/charts/dgraph/templates/alpha-statefulset.yaml
@@ -126,8 +126,8 @@ spec:
         {{- if .Values.alpha.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            port: {{ .Values.alpha.livenessProbe.port }}
-            path: {{ .Values.alpha.livenessProbe.path }}
+            port: {{ .Values.alpha.readinessProbe.port }}
+            path: {{ .Values.alpha.readinessProbe.path }}
           initialDelaySeconds: {{ .Values.alpha.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.alpha.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.alpha.readinessProbe.timeoutSeconds }}

--- a/charts/dgraph/templates/ratel-deployment.yaml
+++ b/charts/dgraph/templates/ratel-deployment.yaml
@@ -60,8 +60,8 @@ spec:
         {{- if .Values.ratel.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            port: {{ .Values.ratel.livenessProbe.port }}
-            path: {{ .Values.ratel.livenessProbe.path }}          
+            port: {{ .Values.ratel.readinessProbe.port }}
+            path: {{ .Values.ratel.readinessProbe.path }}          
           initialDelaySeconds: {{ .Values.ratel.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.ratel.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.ratel.readinessProbe.timeoutSeconds }}

--- a/charts/dgraph/templates/zero-statefulset.yaml
+++ b/charts/dgraph/templates/zero-statefulset.yaml
@@ -131,8 +131,8 @@ spec:
         {{- if .Values.zero.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            port: {{ .Values.zero.livenessProbe.port }}
-            path: {{ .Values.zero.livenessProbe.path }}
+            port: {{ .Values.zero.readinessProbe.port }}
+            path: {{ .Values.zero.readinessProbe.path }}
           initialDelaySeconds: {{ .Values.zero.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.zero.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.zero.readinessProbe.timeoutSeconds }}

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -133,7 +133,7 @@ zero:
   readinessProbe:
     enabled: false
     port: 6080
-    path: /state
+    path: /health
     initialDelaySeconds: 15
     periodSeconds: 10
     timeoutSeconds: 5


### PR DESCRIPTION
Fixes:
* fix alpha `readinessProbe` - was using `livenessProbe` check
* fix zero `readinessProbe` - was using `livenessProbe` check
* fix ratel `readinessProbe` - was using `livenessProbe` check
* update `values.yaml` to use `/health` for zero `readinessProbe`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/32)
<!-- Reviewable:end -->
