### PR TITLE
Service publishNotReadyAddresses value is now configurable

### DIFF
--- a/charts/dgraph/Chart.yaml
+++ b/charts/dgraph/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dgraph
-version: 0.0.5
+version: 0.0.X
 appVersion: v1.2.2
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:

--- a/charts/dgraph/Chart.yaml
+++ b/charts/dgraph/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dgraph
-version: 0.0.X
+version: 0.0.6
 appVersion: v1.2.2
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:

--- a/charts/dgraph/templates/alpha-svc.yaml
+++ b/charts/dgraph/templates/alpha-svc.yaml
@@ -22,9 +22,6 @@ spec:
   - port: 9080
     targetPort: 9080
     name: alpha-grpc
-  # We want all pods in the StatefulSet to have their addresses published for
-  # the sake of the other Dgraph alpha pods even before they're ready, since they
-  # have to be able to talk to each other in order to become ready.
   publishNotReadyAddresses: {{ .Values.alpha.service.publishNotReadyAddresses }}
   selector:
     app: {{ template "dgraph.name" . }}

--- a/charts/dgraph/templates/alpha-svc.yaml
+++ b/charts/dgraph/templates/alpha-svc.yaml
@@ -25,7 +25,7 @@ spec:
   # We want all pods in the StatefulSet to have their addresses published for
   # the sake of the other Dgraph alpha pods even before they're ready, since they
   # have to be able to talk to each other in order to become ready.
-  publishNotReadyAddresses: true
+  publishNotReadyAddresses: {{ .Values.alpha.service.publishNotReadyAddresses }}
   selector:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/zero-svc.yaml
+++ b/charts/dgraph/templates/zero-svc.yaml
@@ -22,9 +22,6 @@ spec:
   - port: 6080
     targetPort: 6080
     name: zero-http
-  # We want all pods in the StatefulSet to have their addresses published for
-  # the sake of the other Dgraph zero pods even before they're ready, since they
-  # have to be able to talk to each other in order to become ready.
   publishNotReadyAddresses: {{ .Values.zero.service.publishNotReadyAddresses }}
   selector:
     app: {{ template "dgraph.name" . }}

--- a/charts/dgraph/templates/zero-svc.yaml
+++ b/charts/dgraph/templates/zero-svc.yaml
@@ -25,7 +25,7 @@ spec:
   # We want all pods in the StatefulSet to have their addresses published for
   # the sake of the other Dgraph zero pods even before they're ready, since they
   # have to be able to talk to each other in order to become ready.
-  publishNotReadyAddresses: true
+  publishNotReadyAddresses: {{ .Values.zero.service.publishNotReadyAddresses }}
   selector:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -82,6 +82,9 @@ zero:
   service:
     type: ClusterIP
     annotations: {}
+    ## StatefulSet pods will need to have addresses published in order to 
+    ## communicate to each other in order to enter a ready state.
+    publishNotReadyAddresses: true
 
   ## dgraph Pod Security Context
   securityContext:
@@ -193,6 +196,9 @@ alpha:
   service:
     type: ClusterIP
     annotations: {}
+    ## StatefulSet pods will need to have addresses published in order to 
+    ## communicate to each other in order to enter a ready state.
+    publishNotReadyAddresses: true
 
   ## alpha ingress resource configuration
   ## This requires an ingress controller to be installed into your k8s cluster


### PR DESCRIPTION
## Description

The `publishNotReadyAddresses` for a service resource is an immutable static value in the template, which will prevent a cluster from becoming ready in alternative orchestration patterns, such as using Itsio.  This allows user to change the value should the need arise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/34)
<!-- Reviewable:end -->
