### PR TITLE
Alpha multi zero support

### DIFF
--- a/charts/dgraph/Chart.yaml
+++ b/charts/dgraph/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dgraph
-version: 0.0.6
+version: 0.0.7
 appVersion: v20.03.3
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:

--- a/charts/dgraph/templates/alpha-statefulset.yaml
+++ b/charts/dgraph/templates/alpha-statefulset.yaml
@@ -18,15 +18,15 @@
       {{- printf "--tls_use_system_ca " -}}
   {{- end -}}
 {{- end }}
-{{- /* Generate Comma Seperated List of Zeros */}}
+{{- /* Generate comma-separated list of Zeros */}}
 {{- define "multi_zeros" -}}
   {{- $zeroFullName := include "dgraph.zero.fullname" . -}}
   {{- $max := int .Values.zero.replicaCount -}}
-  {{- /* Reset $max to 1 if multiple zeros not supported dgraph version */}}
-  {{- if semverCompare "< 1.2.3" .Values.image.tag -}}
+  {{- /* Reset $max to 1 if multiple zeros not supported by dgraph version */}}
+  {{- if semverCompare "< 1.2.3 || 20.03.0" .Values.image.tag -}}
      {{- $max = 1 -}}
   {{- end -}}
-  {{- /* Create Comman seperated List Zeros */}}    
+  {{- /* Create comma-separated list of zeros */}}
   {{- range $idx := until $max }}
     {{- printf "%s-%d.%s-headless.${POD_NAMESPACE}.svc.cluster.local:5080" $zeroFullName $idx $zeroFullName -}}
     {{- if ne $idx (sub $max 1) -}}
@@ -162,7 +162,7 @@ spec:
           timeoutSeconds: {{ .Values.alpha.livenessProbe.timeoutSeconds }}
           successThreshold: {{ .Values.alpha.livenessProbe.successThreshold }}
           failureThreshold: {{ .Values.alpha.livenessProbe.failureThreshold }}
-        {{- else if .Values.alpha.customLivenessProbe }} 
+        {{- else if .Values.alpha.customLivenessProbe }}
         livenessProbe: {{- toYaml .Values.alpha.customLivenessProbe | nindent 10 }}
         {{- end }}
         {{- if .Values.alpha.readinessProbe.enabled }}
@@ -175,7 +175,7 @@ spec:
           timeoutSeconds: {{ .Values.alpha.readinessProbe.timeoutSeconds }}
           successThreshold: {{ .Values.alpha.readinessProbe.successThreshold }}
           failureThreshold: {{ .Values.alpha.readinessProbe.failureThreshold }}
-        {{- else if .Values.alpha.customReadinessProbe }} 
+        {{- else if .Values.alpha.customReadinessProbe }}
         readinessProbe: {{- toYaml .Values.alpha.customReadinessProbe | nindent 10 }}
         {{- end }}
         volumeMounts:

--- a/charts/dgraph/templates/alpha-statefulset.yaml
+++ b/charts/dgraph/templates/alpha-statefulset.yaml
@@ -18,11 +18,15 @@
       {{- printf "--tls_use_system_ca " -}}
   {{- end -}}
 {{- end }}
-
+{{- /* Generate Comma Seperated List of Zeros */}}
 {{- define "multi_zeros" -}}
-  {{- /* TODO: $max = 1 if older version */}}
   {{- $zeroFullName := include "dgraph.zero.fullname" . -}}
   {{- $max := int .Values.alpha.replicaCount -}}
+  {{- /* Reset $max to 1 if multiple zeros not supported dgraph version */}}
+  {{- if semverCompare "< 1.2.3" .Values.image.tag -}}
+     {{- $max = 1 -}}
+  {{- end -}}
+  {{- /* Create Comman seperated List Zeros */}}    
   {{- range $idx := until $max }}
     {{- printf "%s-%d.%s-headless.${POD_NAMESPACE}.svc.cluster.local:5080" $zeroFullName $idx $zeroFullName -}}
     {{- if ne $idx (sub $max 1) -}}

--- a/charts/dgraph/templates/alpha-statefulset.yaml
+++ b/charts/dgraph/templates/alpha-statefulset.yaml
@@ -21,7 +21,7 @@
 {{- /* Generate Comma Seperated List of Zeros */}}
 {{- define "multi_zeros" -}}
   {{- $zeroFullName := include "dgraph.zero.fullname" . -}}
-  {{- $max := int .Values.alpha.replicaCount -}}
+  {{- $max := int .Values.zero.replicaCount -}}
   {{- /* Reset $max to 1 if multiple zeros not supported dgraph version */}}
   {{- if semverCompare "< 1.2.3" .Values.image.tag -}}
      {{- $max = 1 -}}

--- a/charts/dgraph/templates/alpha-statefulset.yaml
+++ b/charts/dgraph/templates/alpha-statefulset.yaml
@@ -18,6 +18,18 @@
       {{- printf "--tls_use_system_ca " -}}
   {{- end -}}
 {{- end }}
+
+{{- define "multi_zeros" -}}
+  {{- /* TODO: $max = 1 if older version */}}
+  {{- $zeroFullName := include "dgraph.zero.fullname" . -}}
+  {{- $max := int .Values.alpha.replicaCount -}}
+  {{- range $idx := until $max }}
+    {{- printf "%s-%d.%s-headless.${POD_NAMESPACE}.svc.cluster.local:5080" $zeroFullName $idx $zeroFullName -}}
+    {{- if ne $idx (sub $max 1) -}}
+      {{- print "," -}}
+    {{- end -}}
+  {{ end }}
+{{- end -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -133,7 +145,7 @@ spec:
          - "-c"
          - |
             set -ex
-            dgraph alpha ${TLS_OPTIONS} --my=$(hostname -f):7080 --lru_mb {{ .Values.alpha.lru_mb }} --zero {{ template "dgraph.zero.fullname" . }}-0.{{ template "dgraph.zero.fullname" . }}-headless.${POD_NAMESPACE}.svc.cluster.local:5080
+            dgraph alpha ${TLS_OPTIONS} --my=$(hostname -f):7080 --lru_mb {{ .Values.alpha.lru_mb }} --zero {{ template "multi_zeros" . }}
         resources:
 {{ toYaml .Values.alpha.resources | indent 10 }}
         {{- if .Values.alpha.livenessProbe.enabled }}


### PR DESCRIPTION
### Description

This adds the ability to create a comma separated list of multiple zeros for support dgraph versions for https://github.com/dgraph-io/dgraph/pull/5116/

This is forward and backwards compatible (thanks to Go template Sprig library)

* versions less than v1.2.3 will have single `dgraph-zero.0` item for `alpha --zero` option
* versions equal or greater than v1.2.3 will have multiple zeros, e.g. `dgraph-zero.0`, `dgraph-zero.1`, `dgraph-zero.2`, up to number of `zero.replicaCount` specified by user

Types of tests:
* **Test**: `helm install dgraph-test charts/charts/dgraph`
  **Result**: `dgraph alpha --zero` will have 3 zeros
* **Test** `helm install dgraph-test charts/charts/dgraph --set zero.replicaCount=5`
   **Result**: `dgraph alpha --zero` will have 5 zeros
* **Test** `helm install dgraph-test charts/charts/dgraph --set image.tag=v1.2.2`
  **Result**: `dgraph alpha --zero` will have 1 zero

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/37)
<!-- Reviewable:end -->
