### PR TITLE
startupProbe

### DIFF
--- a/charts/dgraph/Chart.yaml
+++ b/charts/dgraph/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dgraph
-version: 0.0.7
+version: 0.0.8
 appVersion: v20.03.3
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -90,8 +90,10 @@ The following table lists the configurable parameters of the dgraph chart and th
 | `zero.nodeSelector`                      | Node labels for zero pod assignment                                   | `{}`                                                |
 | `zero.tolerations`                       | Zero tolerations                                                      | `[]`                                                |
 | `zero.resources.requests.memory`         | Zero pod resources memory requests                                    | `100Mi`                                             |
+| `zero.startupProbe`                      | Zero startup probes (**NOTE**: only support in Kubernetes v1.16+)     | See `values.yaml` for defaults                      |
 | `zero.livenessProbe`                     | Zero liveness probes                                                  | See `values.yaml` for defaults                      |
 | `zero.readinessProbe`                    | Zero readiness probes                                                 | See `values.yaml` for defaults                      |
+| `zero.customStartupProbe`                | Zero custom startup probes (if `zero.startupProbe` not enabled)       | `{}`                                                |
 | `zero.customLivenessProbe`               | Zero custom liveness probes (if `zero.livenessProbe` not enabled)     | `{}`                                                |
 | `zero.customReadinessProbe`              | Zero custom readiness probes  (if `zero.readinessProbe` not enabled)  | `{}`                                                |
 | `alpha.name`                             | Alpha component name                                                  | `alpha`                                             |
@@ -125,8 +127,10 @@ The following table lists the configurable parameters of the dgraph chart and th
 | `alpha.nodeSelector`                     | Node labels for alpha pod assignment                                  | `{}`                                                |
 | `alpha.tolerations`                      | Alpha tolerations                                                     | `[]`                                                |
 | `alpha.resources.requests.memory`        | Zero pod resources memory request                                     | `100Mi`                                             |
+| `alpha.startupProbe`                     | Alpha startup probes (**NOTE**: only support in Kubernetes v1.16+)    | See `values.yaml` for defaults                      |
 | `alpha.livenessProbe`                    | Alpha liveness probes                                                 | See `values.yaml` for defaults                      |
 | `alpha.readinessProbe`                   | Alpha readiness probes                                                | See `values.yaml` for defaults                      |
+| `alpha.customStartupProbe`               | Alpha custom startup probes (if `alpha.startupProbe` not enabled)     | `{}`                                                |
 | `alpha.customLivenessProbe`              | Alpha custom liveness probes (if `alpha.livenessProbe` not enabled)   | `{}`                                                |
 | `alpha.customReadinessProbe`             | Alpha custom readiness probes (if `alpha.readinessProbe` not enabled) | `{}`                                                |
 | `ratel.name`                             | Ratel component name                                                  | `ratel`                                             |

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -90,7 +90,7 @@ The following table lists the configurable parameters of the dgraph chart and th
 | `zero.nodeSelector`                      | Node labels for zero pod assignment                                   | `{}`                                                |
 | `zero.tolerations`                       | Zero tolerations                                                      | `[]`                                                |
 | `zero.resources.requests.memory`         | Zero pod resources memory requests                                    | `100Mi`                                             |
-| `zero.startupProbe`                      | Zero startup probes (**NOTE**: only support in Kubernetes v1.16+)     | See `values.yaml` for defaults                      |
+| `zero.startupProbe`                      | Zero startup probes (**NOTE**: only supported in Kubernetes v1.16+)   | See `values.yaml` for defaults                      |
 | `zero.livenessProbe`                     | Zero liveness probes                                                  | See `values.yaml` for defaults                      |
 | `zero.readinessProbe`                    | Zero readiness probes                                                 | See `values.yaml` for defaults                      |
 | `zero.customStartupProbe`                | Zero custom startup probes (if `zero.startupProbe` not enabled)       | `{}`                                                |
@@ -127,7 +127,7 @@ The following table lists the configurable parameters of the dgraph chart and th
 | `alpha.nodeSelector`                     | Node labels for alpha pod assignment                                  | `{}`                                                |
 | `alpha.tolerations`                      | Alpha tolerations                                                     | `[]`                                                |
 | `alpha.resources.requests.memory`        | Zero pod resources memory request                                     | `100Mi`                                             |
-| `alpha.startupProbe`                     | Alpha startup probes (**NOTE**: only support in Kubernetes v1.16+)    | See `values.yaml` for defaults                      |
+| `alpha.startupProbe`                     | Alpha startup probes (**NOTE**: only supported in Kubernetes v1.16+)  | See `values.yaml` for defaults                      |
 | `alpha.livenessProbe`                    | Alpha liveness probes                                                 | See `values.yaml` for defaults                      |
 | `alpha.readinessProbe`                   | Alpha readiness probes                                                | See `values.yaml` for defaults                      |
 | `alpha.customStartupProbe`               | Alpha custom startup probes (if `alpha.startupProbe` not enabled)     | `{}`                                                |

--- a/charts/dgraph/templates/alpha-statefulset.yaml
+++ b/charts/dgraph/templates/alpha-statefulset.yaml
@@ -152,6 +152,20 @@ spec:
             dgraph alpha ${TLS_OPTIONS} --my=$(hostname -f):7080 --lru_mb {{ .Values.alpha.lru_mb }} --zero {{ template "multi_zeros" . }}
         resources:
 {{ toYaml .Values.alpha.resources | indent 10 }}
+        {{- if .Values.alpha.startupProbe.enabled }}
+        startupProbe:
+          httpGet:
+            port: {{ .Values.alpha.startupProbe.port }}
+            path: {{ .Values.alpha.startupProbe.path }}
+          initialDelaySeconds: {{ .Values.alpha.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.alpha.startupProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.alpha.startupProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.alpha.startupProbe.successThreshold }}
+          failureThreshold: {{ .Values.alpha.startupProbe.failureThreshold }}
+        {{- else if .Values.alpha.customStartupProbe }}
+        startupProbe: {{- toYaml .Values.alpha.customStartupProbe | nindent 10 }}
+        {{- end }}
+
         {{- if .Values.alpha.livenessProbe.enabled }}
         livenessProbe:
           httpGet:

--- a/charts/dgraph/templates/alpha-statefulset.yaml
+++ b/charts/dgraph/templates/alpha-statefulset.yaml
@@ -157,7 +157,6 @@ spec:
           httpGet:
             port: {{ .Values.alpha.startupProbe.port }}
             path: {{ .Values.alpha.startupProbe.path }}
-          initialDelaySeconds: {{ .Values.alpha.startupProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.alpha.startupProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.alpha.startupProbe.timeoutSeconds }}
           successThreshold: {{ .Values.alpha.startupProbe.successThreshold }}

--- a/charts/dgraph/templates/alpha-statefulset.yaml
+++ b/charts/dgraph/templates/alpha-statefulset.yaml
@@ -165,7 +165,6 @@ spec:
         {{- else if .Values.alpha.customStartupProbe }}
         startupProbe: {{- toYaml .Values.alpha.customStartupProbe | nindent 10 }}
         {{- end }}
-
         {{- if .Values.alpha.livenessProbe.enabled }}
         livenessProbe:
           httpGet:

--- a/charts/dgraph/templates/zero-statefulset.yaml
+++ b/charts/dgraph/templates/zero-statefulset.yaml
@@ -122,7 +122,6 @@ spec:
           httpGet:
             port: {{ .Values.zero.startupProbe.port }}
             path: {{ .Values.zero.startupProbe.path }}
-          initialDelaySeconds: {{ .Values.zero.startupProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.zero.startupProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.zero.startupProbe.timeoutSeconds }}
           successThreshold: {{ .Values.zero.startupProbe.successThreshold }}

--- a/charts/dgraph/templates/zero-statefulset.yaml
+++ b/charts/dgraph/templates/zero-statefulset.yaml
@@ -117,6 +117,19 @@ spec:
              fi 
         resources:
 {{ toYaml .Values.zero.resources | indent 10 }}
+        {{- if .Values.zero.startupProbe.enabled }}
+        startupProbe:
+          httpGet:
+            port: {{ .Values.zero.startupProbe.port }}
+            path: {{ .Values.zero.startupProbe.path }}
+          initialDelaySeconds: {{ .Values.zero.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.zero.startupProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.zero.startupProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.zero.startupProbe.successThreshold }}
+          failureThreshold: {{ .Values.zero.startupProbe.failureThreshold }}
+        {{- else if .Values.zero.customStartupProbe }}
+        startupProbe: {{- toYaml .Values.zero.customStartupProbe | nindent 10 }}
+        {{- end }}
         {{- if .Values.zero.livenessProbe.enabled }}
         livenessProbe:
           httpGet:

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -123,6 +123,16 @@ zero:
   ## Configure extra options for liveness and readiness probes
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
   ##
+  startupProbe:
+    enabled: false
+    port: 6080
+    path: /health
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  
   livenessProbe:
     enabled: false
     port: 6080
@@ -144,6 +154,7 @@ zero:
     successThreshold: 1
 
   ## Custom liveness and readiness probes
+  customStartupProbe: {}
   customLivenessProbe: {}
   customReadinessProbe: {}
 
@@ -271,6 +282,16 @@ alpha:
   ## Configure extra options for liveness and readiness probes
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
   ##
+  startupProbe:
+    enabled: false
+    port: 8080
+    path: /health?live=1
+    initialDelaySeconds: 180
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+
   livenessProbe:
     enabled: false
     port: 8080
@@ -292,6 +313,7 @@ alpha:
     successThreshold: 1
 
   ## Custom liveness and readiness probes
+  customStartupProbe: {}
   customLivenessProbe: {}
   customReadinessProbe: {}
 

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -287,7 +287,6 @@ alpha:
     enabled: false
     port: 8080
     path: /health?live=1
-    initialDelaySeconds: 15
     periodSeconds: 10
     timeoutSeconds: 5
     failureThreshold: 30

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -120,14 +120,14 @@ zero:
     requests:
       memory: 100Mi
 
-  ## Configure extra options for liveness and readiness probes
+  ## Configure extra options for startup, liveness and readiness probes.
+  ## NOTE: startupProbe only support in Kubernetes v1.16+
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
   ##
   startupProbe:
     enabled: false
     port: 6080
     path: /health
-    initialDelaySeconds: 30
     periodSeconds: 10
     timeoutSeconds: 5
     failureThreshold: 6
@@ -279,17 +279,18 @@ alpha:
   ## Typically a third of available memory is recommended, keeping the default value to 2048mb
   lru_mb: 2048
 
-  ## Configure extra options for liveness and readiness probes
+  ## Configure extra options for startup, liveness and readiness probes
+  ## NOTE: startupProbe only support in Kubernetes v1.16+
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
   ##
   startupProbe:
     enabled: false
     port: 8080
     path: /health?live=1
-    initialDelaySeconds: 180
+    initialDelaySeconds: 15
     periodSeconds: 10
     timeoutSeconds: 5
-    failureThreshold: 6
+    failureThreshold: 30
     successThreshold: 1
 
   livenessProbe:


### PR DESCRIPTION
This adds an optional `startupProbe` that works with Kubernetes v1.16+.  It will break on default versions of Kubernetes on Amazon EKS, GKE platforms.

You can test this out before deploying with: 

```bash
helm install dgraph-test \
 --set alpha.startupProbe.enabled=true \
 --set zero.startupProbe.enabled=true \
 --set alpha.livenessProbe.enabled=true \
 --set zero.livenessProbe.enabled=true \
 --set alpha.readinessProbe.enabled=true \
 --set zero.readinessProbe.enabled=true \
 --debug \
 --dry-run \
 charts/charts/dgraph/
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/39)
<!-- Reviewable:end -->
