### PR TITLE
fix for image.tag of latest or master will work with multi-zero support

### DIFF
--- a/charts/dgraph/templates/alpha-statefulset.yaml
+++ b/charts/dgraph/templates/alpha-statefulset.yaml
@@ -22,8 +22,13 @@
 {{- define "multi_zeros" -}}
   {{- $zeroFullName := include "dgraph.zero.fullname" . -}}
   {{- $max := int .Values.zero.replicaCount -}}
+  {{- /* Create semverCompare() safe version if 'master' or 'latest' */ -}}
+  {{- $safeVersion := .Values.image.tag -}}
+  {{- if or (eq $safeVersion "latest") (eq $safeVersion "master") -}}
+    {{- $safeVersion = "v50.0.0" -}}
+  {{- end -}}
   {{- /* Reset $max to 1 if multiple zeros not supported by dgraph version */}}
-  {{- if semverCompare "< 1.2.3 || 20.03.0" .Values.image.tag -}}
+  {{- if semverCompare "< 1.2.3 || 20.03.0" $safeVersion -}}
      {{- $max = 1 -}}
   {{- end -}}
   {{- /* Create comma-separated list of zeros */}}


### PR DESCRIPTION
#### Description 
The support for multi-zero `dgraph alpha` setting broke support for `image.tag` set to `master` or `latest`.  This fixes that issue.

### Tests

```bash
# test mult-zero configuration support
TEST_MULTIZERO="v1.2.3 v20.03.1 latest master"
for TESTVER in $TEST_MULTIZERO; do 
  helm install tag-test \
    --set image.tag=$TESTVER \
    --dry-run \
    --debug \
    charts/charts/dgraph/ 2> /dev/null | grep 'dgraph alpha'
done

# test legacy single-zero configuration support
TEST_SINGLEZERO="v1.2.2 v20.03.0"
for TESTVER in $TEST_MULTIZERO; do 
  helm install tag-test \
    --set image.tag=$TESTVER \
    --dry-run \
    --debug \
    charts/charts/dgraph/ 2> /dev/null | grep 'dgraph alpha'
done
```

Fixes https://discuss.dgraph.io/t/helm-chart-0-0-7-fails-when-image-tag-set-to-latest/8878

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/41)
<!-- Reviewable:end -->
