### PR TITLE
fix(ingress): Fix serviceName backend for Ratel ingress.

### DIFF
--- a/charts/dgraph/templates/global-ingress.yaml
+++ b/charts/dgraph/templates/global-ingress.yaml
@@ -54,7 +54,7 @@ spec:
           - path: /
           {{- end }}
             backend:
-              serviceName: {{ template "dgraph.alpha.fullname" . }}
+              serviceName: {{ template "dgraph.ratel.fullname" . }}
               servicePort: 80
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Ratel ingress should go to the Ratel service (not Alpha service).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/44)
<!-- Reviewable:end -->
