### PR TITLE
Backup Support for Volumes

### DIFF
--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -170,6 +170,9 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `backups.nfs.path`                       | NFS Server file share path name                                       | `nil`                                               |
 | `backups.nfs.storage`                    | Storage allocated from NFS volume and claim                           | `512Gi`                                             |
 | `backups.nfs.mountPath`                  | Path to mount volume in Alpha (should match `backup.destination`)     | `/dgraph/backups`                                   |
+| `backups.volume.enabled`                 | Enable mounted volume from a PVC for backups                          | `false`                                             |
+| `backups.volume.claim`                   | Name of PVC previously deployed                                       | `""`                                                |
+| `backups.volume.mountPath`               | Path to mount volume in Alpha (should match `backup.destination`)     | `/dgraph/backups`                                   |
 | `backups.full.enabled`                   | Enable full backups cronjob                                           | `false`                                             |
 | `backups.full.debug`                     | Enable `set -x` for cron shell script                                 | `false`                                             |
 | `backups.full.schedule`                  | Cronjob schedule                                                      | `"0 * * * *"`                                       |

--- a/charts/dgraph/example_values/backup-volume-config.yaml
+++ b/charts/dgraph/example_values/backup-volume-config.yaml
@@ -1,0 +1,23 @@
+## backup-volume-config.yaml
+## * https://dgraph.io/docs/master/enterprise-features/binary-backups/
+##
+## Demonstrates binary backups with custom PVC + PV
+## Note that the PV and PVC must have been previously created before installing
+## this chart.  The PVC must set ReadWriteMany access mode.
+backups:
+  volume:
+    enabled: true
+    claim: rook-celphfs-claim
+    mountPath: &path /dgraph/backups
+  full:
+    enabled: true
+    debug: true
+  incremental:
+    enabled: true
+    debug: true
+  destination: *path
+alpha:
+  configFile:
+    config.hcl: |
+      whitelist = "10.0.0.0/8,172.0.0.0/8,192.168.0.0/16"
+      lru_mb    = 2048

--- a/charts/dgraph/example_values/backup-volume-config.yaml
+++ b/charts/dgraph/example_values/backup-volume-config.yaml
@@ -7,7 +7,7 @@
 backups:
   volume:
     enabled: true
-    claim: rook-celphfs-claim
+    claim: rook-cephfs-claim
     mountPath: &path /dgraph/backups
   full:
     enabled: true

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -220,8 +220,12 @@ spec:
           mountPath: /dgraph/acl
         {{- end }}
         {{- if and $backupsEnabled .Values.backups.nfs.enabled }}
-        - name: backups-volume
+        - name: backups-nfs-volume
           mountPath: {{ .Values.backups.nfs.mountPath }}
+        {{- end }}
+        {{- if and $backupsEnabled .Values.backups.volume.enabled }}
+        - name: backups-vol-volume
+          mountPath: {{ .Values.backups.volume.mountPath }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.alpha.terminationGracePeriodSeconds }}
       volumes:
@@ -234,9 +238,14 @@ spec:
           secretName: {{ template "dgraph.backups.fullname" . }}-secret
       {{- end }}
       {{- if and $backupsEnabled .Values.backups.nfs.enabled }}
-      - name: backups-volume
+      - name: backups-nfs-volume
         persistentVolumeClaim:
           claimName: {{ template "dgraph.backups.fullname" . }}-claim
+      {{- end }}
+      {{- if and $backupsEnabled .Values.backups.volume.enabled }}
+      - name: backups-vol-volume
+        persistentVolumeClaim:
+          claimName: {{ .Values.backups.volume.claim }}
       {{- end }}
       {{- if .Values.alpha.configFile }}
       - name: config-volume

--- a/charts/dgraph/templates/backups/cronjob-full.yaml
+++ b/charts/dgraph/templates/backups/cronjob-full.yaml
@@ -75,10 +75,15 @@ spec:
             - name: backup-secret-volume
               mountPath: /backup_secrets
             {{- end }}
-            ## Mount NFS Backup so that datestamp directories can be created
+            ## Mount NFS Backup volume so that datestamp directories can be created
             {{- if .Values.backups.nfs.enabled }}
-            - name: backups-volume
+            - name: backups-nfs-volume
               mountPath: {{ .Values.backups.nfs.mountPath }}
+            {{- end }}
+            ## Mount Backup volume so that datestamp directories can be created
+            {{- if .Values.backups.volume.enabled }}
+            - name: backups-vol-volume
+              mountPath: {{ .Values.backups.volume.mountPath }}
             {{- end }}
             env:
             - name: POD_NAMESPACE
@@ -111,8 +116,13 @@ spec:
               secretName: {{ template "dgraph.backups.fullname" . }}-secret
           {{- end }}
           {{- if .Values.backups.nfs.enabled }}
-          - name: backups-volume
+          - name: backups-nfs-volume
             persistentVolumeClaim:
               claimName: {{ template "dgraph.backups.fullname" . }}-claim
+          {{- end }}
+          {{- if .Values.backups.volume.enabled }}
+          - name: backups-vol-volume
+            persistentVolumeClaim:
+              claimName: {{ .Values.backups.volume.claim }}
           {{- end }}
 {{- end }}

--- a/charts/dgraph/templates/backups/cronjob-inc.yaml
+++ b/charts/dgraph/templates/backups/cronjob-inc.yaml
@@ -75,10 +75,15 @@ spec:
             - name: backup-secret-volume
               mountPath: /backup_secrets
             {{- end }}
-            ## Mount NFS Backup so that datestamp directories can be created
+            ## Mount NFS Backup volume so that datestamp directories can be created
             {{- if .Values.backups.nfs.enabled }}
-            - name: backups-volume
+            - name: backups-nfs-volume
               mountPath: {{ .Values.backups.nfs.mountPath }}
+            {{- end }}
+            ## Mount Backup volume so that datestamp directories can be created
+            {{- if .Values.backups.volume.enabled }}
+            - name: backups-vol-volume
+              mountPath: {{ .Values.backups.volume.mountPath }}
             {{- end }}
             env:
             - name: POD_NAMESPACE
@@ -111,8 +116,13 @@ spec:
               secretName: {{ template "dgraph.backups.fullname" . }}-secret
           {{- end }}
           {{- if .Values.backups.nfs.enabled }}
-          - name: backups-volume
+          - name: backups-nfs-volume
             persistentVolumeClaim:
               claimName: {{ template "dgraph.backups.fullname" . }}-claim
+          {{- end }}
+          {{- if .Values.backups.volume.enabled }}
+          - name: backups-vol-volume
+            persistentVolumeClaim:
+              claimName: {{ .Values.backups.volume.claim }}
           {{- end }}
 {{- end }}

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -433,8 +433,8 @@ backups:
   ## default is to reuse dgraph image
   image:
     << : *image
-  ## NFS Configuration for mounting in Alpha pods
-  ## Prerequisites: NFS Server required, e.g. Google Cloud FileStore, EFS, Azure Blob, etc.
+  ## NFS Configuration for mounting a filepath in Alpha pods
+  ## Prerequisites: NFS Server required, e.g. Google Cloud FileStore, EFS, etc.
   ## ref. https://kubernetes.io/docs/concepts/storage/volumes/#nfs
   nfs:
     enabled: false
@@ -442,8 +442,8 @@ backups:
     path: ""
     storage: 512Gi
     mountPath: &nfs_backups_path /dgraph/backups
-  ## Volume Configuration for mounting in Alpha pods
-  ## Prerequisites: PV and PVC must be created beforehand.
+  ## Volume Configuration for mounting a filepath in Alpha pods
+  ## Prerequisites: PVC must be created beforehand.
   ## On cluster with 2+ alpha pods, RWX (ReadWriteMany) access mode is required.
   ## ref. https://kubernetes.io/docs/concepts/storage/persistent-volumes/
   volume:

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -433,7 +433,7 @@ backups:
   ## default is to reuse dgraph image
   image:
     << : *image
-  ## NFS Configuration for mounting
+  ## NFS Configuration for mounting in Alpha pods
   ## Prerequisites: NFS Server required, e.g. Google Cloud FileStore, EFS, Azure Blob, etc.
   ## ref. https://kubernetes.io/docs/concepts/storage/volumes/#nfs
   nfs:
@@ -441,7 +441,13 @@ backups:
     server: ""
     path: ""
     storage: 512Gi
-    mountPath: &backups_path /dgraph/backups
+    mountPath: &nfs_backups_path /dgraph/backups
+  ## Volume Configuration for mounting in Alpha pods
+  ## Prerequisites: PV and PVC must be created beforehand. PVC must have suppose and set ReadWriteMany access mode.
+  volume:
+    enabled: false
+    claim: ""
+    mountPath: &vol_backups_path /dgraph/backups/
   full:
     enabled: false
     ## enable bash debugging (set -x)
@@ -461,7 +467,7 @@ backups:
   ##   /dgraph/backups
   ##   s3://s3.us-west-2.amazonaws.com/<bucketname>
   ##   minio://my-release-minio.default.svc:9000/<bucketname>
-  destination: *backups_path
+  destination: *nfs_backups_path
   ## subpath directory useful to store full and reclated incremental backuups
   ## in the same directory.
   ## NOTE: It is important to create directory name that matches the schedule.

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -443,7 +443,9 @@ backups:
     storage: 512Gi
     mountPath: &nfs_backups_path /dgraph/backups
   ## Volume Configuration for mounting in Alpha pods
-  ## Prerequisites: PV and PVC must be created beforehand. PVC must have suppose and set ReadWriteMany access mode.
+  ## Prerequisites: PV and PVC must be created beforehand.
+  ## On cluster with 2+ alpha pods, RWX (ReadWriteMany) access mode is required.
+  ## ref. https://kubernetes.io/docs/concepts/storage/persistent-volumes/
   volume:
     enabled: false
     claim: ""
@@ -477,7 +479,7 @@ backups:
   subpath: dgraph_$(date +%Y%m%d)
   ## enable if minio service has https://
   minioSecure: false
-  ## specify access keys required by MinIO or S3 
+  ## specify access keys required by MinIO or S3
   keys:
     minio:
       ## MINIO_ACCESS_KEY env var
@@ -489,7 +491,7 @@ backups:
       access: ""
       ## AWS_SECRET_ACCESS_KEY env var
       secret: ""
-  
+
 global:
   ## Combined ingress resource for alpha and ratel services
   ## This will override existing ingress configurations under alpha and ratel


### PR DESCRIPTION
This adds support for general volumes that can be mounted in Alpha pods, such as EdgeFS, Cassandra, CephFS with Rook (https://rook.io/).  The customer must configure PV + PVC (with ReadWriteMany access mode so that one volume can be mounted under several pods).

## Testing

TL;DR If a default storage class is available, you can use this:

Default Storage Class is helpful (default config in EKS, AKS, GKE):

```bash
cat <<-EOF > pvc.yaml
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: my-backups-claim
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 32Gi
EOF

kubectl apply -f pvc.yaml

CHART_PATH=path/to/charts/charts/dgraph
helm install test \
  --namespace default $CHART_PATH \
  --values $CHART_PATH/example_values/backup-volume-config.yaml \
  --set backups.volume.claim=my-backups-claim 
```

Further research I found these items:

* From my understanding of k8s docs, RWX (ReadWriteMany) for access mode is required for 2+ nodes.  But seems to work in light testing with RWO.  Documenting RWX as a requirement to avoid potential deadlocks.  NFS supports RWX as well as other CSI drivers.
* Other storages for MiniKube (alternatives if needed):
    * https://kubernetes.io/docs/tasks/configure-pod-container/configure-persistent-volume-storage/
    * https://github.com/kubernetes-csi/csi-driver-host-path/tree/master/examples

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/48)
<!-- Reviewable:end -->
