### PR TITLE
feature: generic initContainer (SUCCESS-57)

### DIFF
--- a/charts/dgraph/Chart.yaml
+++ b/charts/dgraph/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dgraph
-version: 0.0.11
+version: 0.0.12
 appVersion: v20.07.1
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:

--- a/charts/dgraph/Chart.yaml
+++ b/charts/dgraph/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: dgraph
 version: 0.0.12
-appVersion: v20.07.1
+appVersion: v20.07.2
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:
 - dgraph

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -138,12 +138,12 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `alpha.customStartupProbe`               | Alpha custom startup probes (if `alpha.startupProbe` not enabled)     | `{}`                                                |
 | `alpha.customLivenessProbe`              | Alpha custom liveness probes (if `alpha.livenessProbe` not enabled)   | `{}`                                                |
 | `alpha.customReadinessProbe`             | Alpha custom readiness probes (if `alpha.readinessProbe` not enabled) | `{}`                                                |
-| `alpha.initContainers.generic.enabled`   | Alpha generic initContainer enabled                                   | `true`                                              |
-| `alpha.initContainers.generic.image.registry`   | generic initContainer registry name                            | `docker.io`                                         |
-| `alpha.initContainers.generic.image.repository` | generic initContainer image name                               | `dgraph/dgraph`                                     |
-| `alpha.initContainers.generic.image.tag`        | generic initContainer image tag                                | `v20.07.2`                                          |
-| `alpha.initContainers.generic.image.pullPolicy` | generic initContainer pull policy                              | `IfNotPresent`                                      |
-| `alpha.initContainers.generic.command`   | Alpha generic initContainer command line to execute                   | See `values.yaml` for defaults                      |
+| `alpha.initContainers.init.enabled`      | Alpha initContainer enabled                                           | `true`                                              |
+| `alpha.initContainers.init.image.registry`   | Alpha initContainer registry name                                 | `docker.io`                                         |
+| `alpha.initContainers.init.image.repository` | Alpha initContainer image name                                    | `dgraph/dgraph`                                     |
+| `alpha.initContainers.init.image.tag`        | Alpha initContainer image tag                                     | `v20.07.2`                                          |
+| `alpha.initContainers.init.image.pullPolicy` | Alpha initContainer pull policy                                   | `IfNotPresent`                                      |
+| `alpha.initContainers.init.command`      | Alpha initContainer command line to execute                           | See `values.yaml` for defaults                      |
 | `ratel.name`                             | Ratel component name                                                  | `ratel`                                             |
 | `ratel.enabled`                          | Ratel service enabled or disabled                                     | `true`                                              |
 | `ratel.replicaCount`                     | Number of ratel nodes                                                 | `1`                                                 |

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -61,7 +61,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | ---------------------------------------- | --------------------------------------------------------------------- | --------------------------------------------------- |
 | `image.registry`                         | Container registry name                                               | `docker.io`                                         |
 | `image.repository`                       | Container image name                                                  | `dgraph/dgraph`                                     |
-| `image.tag`                              | Container image tag                                                   | `v20.07.1`                                          |
+| `image.tag`                              | Container image tag                                                   | `v20.07.2`                                          |
 | `image.pullPolicy`                       | Container pull policy                                                 | `IfNotPresent`                                      |
 | `nameOverride`                           | Deployment name override (will append the release name)               | `nil`                                               |
 | `fullnameOverride`                       | Deployment full name override (the release name is ignored)           | `nil`                                               |
@@ -138,6 +138,12 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `alpha.customStartupProbe`               | Alpha custom startup probes (if `alpha.startupProbe` not enabled)     | `{}`                                                |
 | `alpha.customLivenessProbe`              | Alpha custom liveness probes (if `alpha.livenessProbe` not enabled)   | `{}`                                                |
 | `alpha.customReadinessProbe`             | Alpha custom readiness probes (if `alpha.readinessProbe` not enabled) | `{}`                                                |
+| `alpha.initContainers.generic.enabled`   | Alpha generic initContainer enabled                                   | `true`                                              |
+| `alpha.initContainers.generic.image.registry`   | generic initContainer registry name                            | `docker.io`                                         |
+| `alpha.initContainers.generic.image.repository` | generic initContainer image name                               | `dgraph/dgraph`                                     |
+| `alpha.initContainers.generic.image.tag`        | generic initContainer image tag                                | `v20.07.2`                                          |
+| `alpha.initContainers.generic.image.pullPolicy` | generic initContainer pull policy                              | `IfNotPresent`                                      |
+| `alpha.initContainers.generic.command`   | Alpha generic initContainer command line to execute                   | See `values.yaml` for defaults                      |
 | `ratel.name`                             | Ratel component name                                                  | `ratel`                                             |
 | `ratel.enabled`                          | Ratel service enabled or disabled                                     | `true`                                              |
 | `ratel.replicaCount`                     | Number of ratel nodes                                                 | `1`                                                 |
@@ -163,7 +169,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `backups.admin.auth_token`               | Auth Token                                                            | `nil`                                               |
 | `backups.image.registry`                 | Container registry name                                               | `docker.io`                                         |
 | `backups.image.repository`               | Container image name                                                  | `dgraph/dgraph`                                     |
-| `backups.image.tag`                      | Container image tag                                                   | `v20.07.1`                                          |
+| `backups.image.tag`                      | Container image tag                                                   | `v20.07.2`                                          |
 | `backups.image.pullPolicy`               | Container pull policy                                                 | `IfNotPresent`                                      |
 | `backups.nfs.enabled`                    | Enable mounted NFS volume for backups                                 | `false`                                             |
 | `backups.nfs.server`                     | NFS Server DNS or IP address                                          | `nil`                                               |
@@ -224,7 +230,7 @@ When generating the certificates and keys with `dgraph cert` command, you can us
 export RELEASE="my-release"
 export REPLICAS=3
 export NAMESPACE="default"
-VERS=0.0.11
+VERS=0.0.12
 
 ## Download Script
 curl --silent --remote-name --location \
@@ -240,7 +246,7 @@ dgraph cert --client backupuser
 It is recommended that you keep secrets values and config values in separate YAML files.  To assist with this practice, you can use the [make_tls_secrets.sh](https://github.com/dgraph-io/charts/blob/master/charts/dgraph/scripts/make_tls_secrets.sh) script to generate a `secrets.yaml` file from an existing `./tls` directory that was previously generated by the `dgraph cert` command.
 
 ```bash
-VERS=0.0.11
+VERS=0.0.12
 ## Download Script
 curl --silent --remote-name --location \
   https://raw.githubusercontent.com/dgraph-io/charts/dgraph-$VERS/charts/dgraph/scripts/make_tls_secrets.sh

--- a/charts/dgraph/templates/_helpers.tpl
+++ b/charts/dgraph/templates/_helpers.tpl
@@ -45,7 +45,7 @@ version comparisions used to toggle features or behavior.
 {{- define "dgraph.version" -}}
 {{- $safeVersion := .Values.image.tag -}}
 {{- if (eq $safeVersion "shuri") -}}
-  {{- $safeVersion = "v20.07.0" -}}
+  {{- $safeVersion = "v20.07.1" -}}
 {{- else if  (regexMatch "^[^v].*" $safeVersion) -}}
   {{- $safeVersion = "v50.0.0" -}}
 {{- end -}}
@@ -97,6 +97,16 @@ Return empty string if s3 keys are not defined
   {{- end -}}
 {{- end -}}
 {{- printf "%s" $s3Enabled -}}
+{{- end -}}
+
+{{/*
+Return the initContainers image name
+*/}}
+{{- define "dgraph.initContainers.generic.image" -}}
+{{- $registryName := .Values.alpha.initContainers.generic.image.registry -}}
+{{- $repositoryName := .Values.alpha.initContainers.generic.image.repository -}}
+{{- $tag := .Values.alpha.initContainers.generic.image.tag | toString -}}
+{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
 
 {{/*

--- a/charts/dgraph/templates/_helpers.tpl
+++ b/charts/dgraph/templates/_helpers.tpl
@@ -102,10 +102,10 @@ Return empty string if s3 keys are not defined
 {{/*
 Return the initContainers image name
 */}}
-{{- define "dgraph.initContainers.generic.image" -}}
-{{- $registryName := .Values.alpha.initContainers.generic.image.registry -}}
-{{- $repositoryName := .Values.alpha.initContainers.generic.image.repository -}}
-{{- $tag := .Values.alpha.initContainers.generic.image.tag | toString -}}
+{{- define "dgraph.initContainers.init.image" -}}
+{{- $registryName := .Values.alpha.initContainers.init.image.registry -}}
+{{- $repositoryName := .Values.alpha.initContainers.init.image.repository -}}
+{{- $tag := .Values.alpha.initContainers.init.image.tag | toString -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
 

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -18,7 +18,7 @@
 {{- $hasS3Keys := include "dgraph.backups.keys.s3.enabled" . -}}
 {{- $hasMinioKeys := include "dgraph.backups.keys.minio.enabled" . -}}
 {{- $backupsEnabled := or .Values.backups.full.enabled .Values.backups.incremental.enabled }}
-{{- $initContainerEnabled := .Values.alpha.initContainers.generic.enabled }}
+{{- $initContainerEnabled := .Values.alpha.initContainers.init.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -108,12 +108,12 @@ spec:
       {{- end }}
       {{- if $initContainerEnabled }}
       initContainers:
-      {{- if .Values.alpha.initContainers.generic.enabled }}
-      - name: {{ template "dgraph.alpha.fullname" . }}-init-generic
-        image: {{ template "dgraph.initContainers.generic.image" . }}
-        imagePullPolicy: {{ .Values.alpha.initContainers.generic.image.pullPolicy | quote }}
+      {{- if .Values.alpha.initContainers.init.enabled }}
+      - name: {{ template "dgraph.alpha.fullname" . }}-init-init
+        image: {{ template "dgraph.initContainers.init.image" . }}
+        imagePullPolicy: {{ .Values.alpha.initContainers.init.image.pullPolicy | quote }}
         command:
-        {{- range .Values.alpha.initContainers.generic.command }}
+        {{- range .Values.alpha.initContainers.init.command }}
           - {{ . | quote }}
         {{- end }}
         {{- if .Values.alpha.persistence.enabled }}

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -18,6 +18,7 @@
 {{- $hasS3Keys := include "dgraph.backups.keys.s3.enabled" . -}}
 {{- $hasMinioKeys := include "dgraph.backups.keys.minio.enabled" . -}}
 {{- $backupsEnabled := or .Values.backups.full.enabled .Values.backups.incremental.enabled }}
+{{- $initContainerEnabled := .Values.alpha.initContainers.generic.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -105,8 +106,9 @@ spec:
       tolerations:
 {{ toYaml .Values.alpha.tolerations | indent 8 }}
       {{- end }}
-      {{- if .Values.alpha.initContainers.enabled }}
+      {{- if $initContainerEnabled }}
       initContainers:
+      {{- if .Values.alpha.initContainers.generic.enabled }}
       - name: {{ template "dgraph.alpha.fullname" . }}-init-generic
         image: {{ template "dgraph.initContainers.generic.image" . }}
         imagePullPolicy: {{ .Values.alpha.initContainers.generic.image.pullPolicy | quote }}
@@ -119,6 +121,7 @@ spec:
         - name: datadir
           mountPath: /dgraph
         {{- end }}
+      {{- end }}
       {{- end }}
       containers:
       - name: {{ template "dgraph.alpha.fullname" . }}

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -105,6 +105,21 @@ spec:
       tolerations:
 {{ toYaml .Values.alpha.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.alpha.initContainers.enabled }}
+      initContainers:
+      - name: {{ template "dgraph.alpha.fullname" . }}-init-generic
+        image: {{ template "dgraph.initContainers.generic.image" . }}
+        imagePullPolicy: {{ .Values.alpha.initContainers.generic.image.pullPolicy | quote }}
+        command:
+        {{- range .Values.alpha.initContainers.generic.command }}
+          - {{ . | quote }}
+        {{- end }}
+        {{- if .Values.alpha.persistence.enabled }}
+        volumeMounts:
+        - name: datadir
+          mountPath: /dgraph
+        {{- end }}
+      {{- end }}
       containers:
       - name: {{ template "dgraph.alpha.fullname" . }}
         image: {{ template "dgraph.image" . }}

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -345,7 +345,7 @@ alpha:
   ##   (ref. https://dgraph.io/docs/enterprise-features/binary-backups/#restore-from-backup)
   ## * bulk loader (ref. https://dgraph.io/docs/deploy/fast-data-loading/#bulk-loader)
   initContainers:
-    generic:
+    init:
       enabled: false
       image:
         << : *image

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -10,7 +10,7 @@
 image: &image
   registry: docker.io
   repository: dgraph/dgraph
-  tag: v20.07.1
+  tag: v20.07.2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -345,8 +345,8 @@ alpha:
   ##   (ref. https://dgraph.io/docs/enterprise-features/binary-backups/#restore-from-backup)
   ## * bulk loader (ref. https://dgraph.io/docs/deploy/fast-data-loading/#bulk-loader)
   initContainers:
-    enabled: false
     generic:
+      enabled: false
       image:
         << : *image
       command:

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -339,6 +339,23 @@ alpha:
   customLivenessProbe: {}
   customReadinessProbe: {}
 
+  ## You may want to initialize the Alphas with data before starting Alpha containers.
+  ## Examples can include:
+  ## * offline data restore from binary backups with `dgraph restore`
+  ##   (ref. https://dgraph.io/docs/enterprise-features/binary-backups/#restore-from-backup)
+  ## * bulk loader (ref. https://dgraph.io/docs/deploy/fast-data-loading/#bulk-loader)
+  initContainers:
+    enabled: false
+    generic:
+      image:
+        << : *image
+      command:
+        - bash
+        - "-c"
+        - |
+          trap "exit" SIGINT SIGTERM
+          echo "Write to /dgraph/doneinit when ready."
+          until [ -f /dgraph/doneinit ]; do sleep 2; done
 
 ratel:
   name: ratel


### PR DESCRIPTION
This adds a generic init container for the helm chart where operators can do some pre-cluster operations, such as _offline restore_ or _bulk loader_ before the alpha group starts up.  

The operator can use this for anything type of script they chose, or default and run ad-hoc commands and then `touch /dgraph/doneinit` once completed.

This is forward compatible with future restore initContainer and bulkloader initContainer, which will be added later.

### Testing

```bash
### Test without Feature
helm install t1 --set alpha.initContainers.generic.enabled=false charts/dgraph/

helm delete t1 && kubectl delete pvc -l release=t1

### Test with Feature
helm install t2 --set alpha.initContainers.generic.enabled=true charts/dgraph/
kubectl exec -ti t2-dgraph-alpha-0 -c t2-dgraph-alpha-init-generic -- touch doneinit
kubectl exec -ti t2-dgraph-alpha-1 -c t2-dgraph-alpha-init-generic -- touch doneinit
kubectl exec -ti t2-dgraph-alpha-2 -c t2-dgraph-alpha-init-generic -- touch doneinit

helm delete t2 && kubectl delete pvc -l release=t2
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/49)
<!-- Reviewable:end -->
