### PR TITLE
fix: remove using fqdn with `.cluster.local`

### DIFF
--- a/charts/dgraph/scripts/get_alpha_list.sh
+++ b/charts/dgraph/scripts/get_alpha_list.sh
@@ -7,12 +7,10 @@ get_alpha_list() {
   RELEASE=${RELEASE:-"my-release"}
   ## namespace used during deployment
   NAMESPACE=${NAMESPACE:-"default"}
-  ## kubernetes domain, typically cluster.local
-  DOMAIN=${DOMAIN:-"cluster.local"}
 
   ## Build List
   for (( IDX=0; IDX<REPLICAS; IDX++ )); do
-    LIST+=("$RELEASE-dgraph-alpha-$IDX.$RELEASE-dgraph-alpha-headless.$NAMESPACE.svc.$DOMAIN")
+    LIST+=("$RELEASE-dgraph-alpha-$IDX.$RELEASE-dgraph-alpha-headless.$NAMESPACE.svc")
   done
 
   ## Output Comma Separated List

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -9,7 +9,7 @@
   {{- end -}}
   {{- /* Create comma-separated list of zeros */}}
   {{- range $idx := until $max }}
-    {{- printf "%s-%d.%s-headless.${POD_NAMESPACE}.svc.cluster.local:5080" $zeroFullName $idx $zeroFullName -}}
+    {{- printf "%s-%d.%s-headless.${POD_NAMESPACE}.svc:5080" $zeroFullName $idx $zeroFullName -}}
     {{- if ne $idx (sub $max 1) -}}
       {{- print "," -}}
     {{- end -}}

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -157,7 +157,7 @@ spec:
          - "-c"
          - |
             set -ex
-            dgraph alpha --my=$(hostname -f):7080 --zero {{ template "multi_zeros" . }}
+            dgraph alpha --my=$(hostname -f | awk '{gsub(/\.$/,""); print $0}'):7080 --zero {{ template "multi_zeros" . }}
         resources:
 {{ toYaml .Values.alpha.resources | indent 10 }}
         {{- if .Values.alpha.startupProbe.enabled }}

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -152,9 +152,12 @@ spec:
         {{- with .Values.alpha.extraEnvs }}
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{/* NOTE: awk '{gsub(/\.$/,"") needed to trim */}}
         command:
          - bash
          - "-c"
+         ## NOTE: awk gsub need to trim trailing period as it causes crash for Kubernetes w/o domain name
+         {{/* TODO: Remove awk-gsub once dgraph-io/dgraph#6837 merged and back-ported. */}}
          - |
             set -ex
             dgraph alpha --my=$(hostname -f | awk '{gsub(/\.$/,""); print $0}'):7080 --zero {{ template "multi_zeros" . }}

--- a/charts/dgraph/templates/backups/cronjob-full.yaml
+++ b/charts/dgraph/templates/backups/cronjob-full.yaml
@@ -46,7 +46,7 @@ spec:
 
                 ## Use Single Alpha in Cluster to avoid potential issues with concurrent backups
                 ## ref. https://discuss.dgraph.io/t/concurrent-backups-can-lead-to-issues/9934/2
-                ALPHA_HOST="{{ template "dgraph.alpha.fullname" . }}-0.{{ template "dgraph.alpha.fullname" . }}-headless.${POD_NAMESPACE}.svc.cluster.local"
+                ALPHA_HOST="{{ template "dgraph.alpha.fullname" . }}-0.{{ template "dgraph.alpha.fullname" . }}-headless.${POD_NAMESPACE}.svc"
 
                 BACKUP_DESTINATION={{ .Values.backups.destination }}
                 SUBPATH={{ .Values.backups.subpath }}

--- a/charts/dgraph/templates/backups/cronjob-inc.yaml
+++ b/charts/dgraph/templates/backups/cronjob-inc.yaml
@@ -46,7 +46,7 @@ spec:
 
                 ## Use Single Alpha in Cluster to avoid potential issues with concurrent backups
                 ## ref. https://discuss.dgraph.io/t/concurrent-backups-can-lead-to-issues/9934/2
-                ALPHA_HOST="{{ template "dgraph.alpha.fullname" . }}-0.{{ template "dgraph.alpha.fullname" . }}-headless.${POD_NAMESPACE}.svc.cluster.local"
+                ALPHA_HOST="{{ template "dgraph.alpha.fullname" . }}-0.{{ template "dgraph.alpha.fullname" . }}-headless.${POD_NAMESPACE}.svc"
 
                 BACKUP_DESTINATION={{ .Values.backups.destination }}
                 SUBPATH={{ .Values.backups.subpath }}

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -117,8 +117,8 @@ spec:
              if [[ $ordinal -eq 0 ]]; then
                exec dgraph zero --my=$(hostname -f):5080 --idx $idx --replicas {{ .Values.zero.shardReplicaCount }}
              else
-               exec dgraph zero --my=$(hostname -f):5080 --peer {{ template "dgraph.zero.fullname" . }}-0.{{ template "dgraph.zero.fullname" . }}-headless.${POD_NAMESPACE}.svc.cluster.local:5080 --idx $idx --replicas {{ .Values.zero.shardReplicaCount }}
-             fi 
+               exec dgraph zero --my=$(hostname -f):5080 --peer {{ template "dgraph.zero.fullname" . }}-0.{{ template "dgraph.zero.fullname" . }}-headless.${POD_NAMESPACE}.svc:5080 --idx $idx --replicas {{ .Values.zero.shardReplicaCount }}
+             fi
         resources:
 {{ toYaml .Values.zero.resources | indent 10 }}
         {{- if .Values.zero.startupProbe.enabled }}
@@ -175,7 +175,7 @@ spec:
           claimName: datadir
      {{- if .Values.zero.configFile }}
       - name: config-volume
-        configMap: 
+        configMap:
           name: {{ template "dgraph.zero.fullname" . }}-config
       {{- end }}
 {{- if .Values.zero.persistence.enabled }}

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -115,9 +115,9 @@ spec:
              ordinal=${BASH_REMATCH[1]}
              idx=$(($ordinal + 1))
              if [[ $ordinal -eq 0 ]]; then
-               exec dgraph zero --my=$(hostname -f):5080 --idx $idx --replicas {{ .Values.zero.shardReplicaCount }}
+               exec dgraph zero --my=$(hostname -f | awk '{gsub(/\.$/,""); print $0}'):5080 --idx $idx --replicas {{ .Values.zero.shardReplicaCount }}
              else
-               exec dgraph zero --my=$(hostname -f):5080 --peer {{ template "dgraph.zero.fullname" . }}-0.{{ template "dgraph.zero.fullname" . }}-headless.${POD_NAMESPACE}.svc:5080 --idx $idx --replicas {{ .Values.zero.shardReplicaCount }}
+               exec dgraph zero --my=$(hostname -f | awk '{gsub(/\.$/,""); print $0}'):5080 --peer {{ template "dgraph.zero.fullname" . }}-0.{{ template "dgraph.zero.fullname" . }}-headless.${POD_NAMESPACE}.svc:5080 --idx $idx --replicas {{ .Values.zero.shardReplicaCount }}
              fi
         resources:
 {{ toYaml .Values.zero.resources | indent 10 }}


### PR DESCRIPTION
This removes references to the FQDN with domain name of **`cluster.local`**, for example: 

* BEFORE: **`myrelease-dgraph-zero-0.myrelease-dgraph-zero-headless.default.svc.cluster.local`**
* AFTER: **`myrelease-dgraph-zero-0.myrelease-dgraph-zero-headless.default.svc`**

This fixes a few scenarios:

* Local clusters, such as [microk8s](https://microk8s.io/), where a domain name is not used.
* Alternative internal DNS schemes where default **`cluster.local`** is not use
  * https://discuss.dgraph.io/t/helm-chart-defaults-to-cluster-local/8269/3

This works because the resolver should always have **`cluster.lcoal`** or equivalent alternative domain name.  For example, on GKE, these search domains will be configured:

* **`default.svc.cluster.local`**
* **`svc.cluster.local`** 
* **`cluster.local`**
* **`c.${PROJECT_ID}.internal`** 
* **`google.internal`**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/50)
<!-- Reviewable:end -->
