### PR TITLE
Feature: Extra Flags (SUCCESS-136)

### DIFF
--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -77,7 +77,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `zero.podAntiAffinitytopologyKey`        | Anti affinity topology key for zero nodes                             | `kubernetes.io/hostname`                            |
 | `zero.nodeAffinity`                      | Zero node affinity policy                                             | `{}`                                                |
 | `zero.extraEnvs`                         | extra env vars                                                        | `[]`                                                |
-| `zero.command.override`                  | Zero command override that replaces default command                   | `[]`                                                |
+| `zero.extraFlags`                        | Zero extra flags for command line                                     | `""`                                                |
 | `zero.configFile`                        | Zero config file                                                      | `{}`                                                |
 | `zero.service.type`                      | Zero service type                                                     | `ClusterIP`                                         |
 | `zero.service.annotations`               | Zero service annotations                                              | `{}`                                                |
@@ -109,7 +109,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `alpha.podAntiAffinitytopologyKey`       | Anti affinity topology key for zero nodes                             | `kubernetes.io/hostname`                            |
 | `alpha.nodeAffinity`                     | Alpha node affinity policy                                            | `{}`                                                |
 | `alpha.extraEnvs`                        | extra env vars                                                        | `[]`                                                |
-| `alpha.command.override`                 | Alpha command override that replaces default command                  | `[]`                                                |
+| `alpha.extraFlags`                       | Alpha extra flags for command                                         | `""`                                                |
 | `alpha.configFile`                       | Alpha config file                                                     | `{ config.yaml: 'lru_mb: 2048' }`                   |
 | `alpha.service.type`                     | Alpha node service type                                               | `ClusterIP`                                         |
 | `alpha.service.annotations`              | Alpha service annotations                                             | `{}`                                                |

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -77,6 +77,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `zero.podAntiAffinitytopologyKey`        | Anti affinity topology key for zero nodes                             | `kubernetes.io/hostname`                            |
 | `zero.nodeAffinity`                      | Zero node affinity policy                                             | `{}`                                                |
 | `zero.extraEnvs`                         | extra env vars                                                        | `[]`                                                |
+| `zero.command.override`                  | Zero command override that replaces default command                   | `[]`                                                |
 | `zero.configFile`                        | Zero config file                                                      | `{}`                                                |
 | `zero.service.type`                      | Zero service type                                                     | `ClusterIP`                                         |
 | `zero.service.annotations`               | Zero service annotations                                              | `{}`                                                |
@@ -108,6 +109,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `alpha.podAntiAffinitytopologyKey`       | Anti affinity topology key for zero nodes                             | `kubernetes.io/hostname`                            |
 | `alpha.nodeAffinity`                     | Alpha node affinity policy                                            | `{}`                                                |
 | `alpha.extraEnvs`                        | extra env vars                                                        | `[]`                                                |
+| `alpha.command.override`                 | Alpha command override that replaces default command                  | `[]`                                                |
 | `alpha.configFile`                       | Alpha config file                                                     | `{ config.yaml: 'lru_mb: 2048' }`                   |
 | `alpha.service.type`                     | Alpha node service type                                               | `ClusterIP`                                         |
 | `alpha.service.annotations`              | Alpha service annotations                                             | `{}`                                                |

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -172,20 +172,14 @@ spec:
         {{- end }}
         {{/* NOTE: awk '{gsub(/\.$/,"") needed to trim */}}
         command:
-        {{- if .Values.alpha.command.override }}
-        {{- range .Values.alpha.command.override }}
-        - {{ . | quote }}
-        {{- end }}
-        {{- else }}
-        - bash
-        - "-c"
-        ## NOTE: awk gsub is needed to trim trailing period otherwise it causes
-        ##       crash for Kubernetes without the domain name
-        {{- /* TODO: Remove awk-gsub once dgraph-io/dgraph#6837 is merged and back-ported. */}}
-        - |
-           set -ex
-           dgraph alpha --my=$(hostname -f | awk '{gsub(/\.$/,""); print $0}'):7080 --zero {{ template "multi_zeros" . }}
-        {{- end }}
+          - bash
+          - "-c"
+          ## NOTE: awk gsub is needed to trim trailing period otherwise it causes
+          ##       crash for Kubernetes without the domain name
+          {{- /* TODO: Remove awk-gsub once dgraph-io/dgraph#6837 is merged and back-ported. */}}
+          - |
+            set -ex
+            dgraph alpha --my=$(hostname -f | awk '{gsub(/\.$/,""); print $0}'):7080 --zero {{ template "multi_zeros" . }} {{ .Values.alpha.extraFlags }}
         resources:
 {{ toYaml .Values.alpha.resources | indent 10 }}
         {{- if .Values.alpha.startupProbe.enabled }}

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -109,7 +109,7 @@ spec:
       {{- if $initContainerEnabled }}
       initContainers:
       {{- if .Values.alpha.initContainers.init.enabled }}
-      - name: {{ template "dgraph.alpha.fullname" . }}-init-init
+      - name: {{ template "dgraph.alpha.fullname" . }}-init
         image: {{ template "dgraph.initContainers.init.image" . }}
         imagePullPolicy: {{ .Values.alpha.initContainers.init.image.pullPolicy | quote }}
         command:
@@ -172,14 +172,20 @@ spec:
         {{- end }}
         {{/* NOTE: awk '{gsub(/\.$/,"") needed to trim */}}
         command:
-         - bash
-         - "-c"
-         ## NOTE: awk gsub is needed to trim trailing period otherwise it causes
-         ##       crash for Kubernetes without the domain name
-         {{/* TODO: Remove awk-gsub once dgraph-io/dgraph#6837 is merged and back-ported. */}}
-         - |
-            set -ex
-            dgraph alpha --my=$(hostname -f | awk '{gsub(/\.$/,""); print $0}'):7080 --zero {{ template "multi_zeros" . }}
+        {{- if .Values.alpha.command.override }}
+        {{- range .Values.alpha.command.override }}
+        - {{ . | quote }}
+        {{- end }}
+        {{- else }}
+        - bash
+        - "-c"
+        ## NOTE: awk gsub is needed to trim trailing period otherwise it causes
+        ##       crash for Kubernetes without the domain name
+        {{- /* TODO: Remove awk-gsub once dgraph-io/dgraph#6837 is merged and back-ported. */}}
+        - |
+           set -ex
+           dgraph alpha --my=$(hostname -f | awk '{gsub(/\.$/,""); print $0}'):7080 --zero {{ template "multi_zeros" . }}
+        {{- end }}
         resources:
 {{ toYaml .Values.alpha.resources | indent 10 }}
         {{- if .Values.alpha.startupProbe.enabled }}

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -107,24 +107,18 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         command:
-        {{- if .Values.zero.command.override }}
-        {{- range .Values.zero.command.override }}
-        - {{ . | quote }}
-        {{- end }}
-        {{- else }}
-        - bash
-        - "-c"
-        - |
-           set -ex
-           [[ `hostname` =~ -([0-9]+)$ ]] || exit 1
-            ordinal=${BASH_REMATCH[1]}
-            idx=$(($ordinal + 1))
-            if [[ $ordinal -eq 0 ]]; then
-              exec dgraph zero --my=$(hostname -f | awk '{gsub(/\.$/,""); print $0}'):5080 --idx $idx --replicas {{ .Values.zero.shardReplicaCount }}
-            else
-              exec dgraph zero --my=$(hostname -f | awk '{gsub(/\.$/,""); print $0}'):5080 --peer {{ template "dgraph.zero.fullname" . }}-0.{{ template "dgraph.zero.fullname" . }}-headless.${POD_NAMESPACE}.svc:5080 --idx $idx --replicas {{ .Values.zero.shardReplicaCount }}
-            fi
-        {{- end }}
+          - bash
+          - "-c"
+          - |
+            set -ex
+            [[ `hostname` =~ -([0-9]+)$ ]] || exit 1
+              ordinal=${BASH_REMATCH[1]}
+              idx=$(($ordinal + 1))
+              if [[ $ordinal -eq 0 ]]; then
+                exec dgraph zero --my=$(hostname -f | awk '{gsub(/\.$/,""); print $0}'):5080 --idx $idx --replicas {{ .Values.zero.shardReplicaCount }} {{ .Values.zero.extraFlags }}
+              else
+                exec dgraph zero --my=$(hostname -f | awk '{gsub(/\.$/,""); print $0}'):5080 --peer {{ template "dgraph.zero.fullname" . }}-0.{{ template "dgraph.zero.fullname" . }}-headless.${POD_NAMESPACE}.svc:5080 --idx $idx --replicas {{ .Values.zero.shardReplicaCount }} {{ .Values.zero.extraFlags }}
+              fi
         resources:
 {{ toYaml .Values.zero.resources | indent 10 }}
         {{- if .Values.zero.startupProbe.enabled }}

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -107,18 +107,24 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         command:
-         - bash
-         - "-c"
-         - |
-            set -ex
-            [[ `hostname` =~ -([0-9]+)$ ]] || exit 1
-             ordinal=${BASH_REMATCH[1]}
-             idx=$(($ordinal + 1))
-             if [[ $ordinal -eq 0 ]]; then
-               exec dgraph zero --my=$(hostname -f | awk '{gsub(/\.$/,""); print $0}'):5080 --idx $idx --replicas {{ .Values.zero.shardReplicaCount }}
-             else
-               exec dgraph zero --my=$(hostname -f | awk '{gsub(/\.$/,""); print $0}'):5080 --peer {{ template "dgraph.zero.fullname" . }}-0.{{ template "dgraph.zero.fullname" . }}-headless.${POD_NAMESPACE}.svc:5080 --idx $idx --replicas {{ .Values.zero.shardReplicaCount }}
-             fi
+        {{- if .Values.zero.command.override }}
+        {{- range .Values.zero.command.override }}
+        - {{ . | quote }}
+        {{- end }}
+        {{- else }}
+        - bash
+        - "-c"
+        - |
+           set -ex
+           [[ `hostname` =~ -([0-9]+)$ ]] || exit 1
+            ordinal=${BASH_REMATCH[1]}
+            idx=$(($ordinal + 1))
+            if [[ $ordinal -eq 0 ]]; then
+              exec dgraph zero --my=$(hostname -f | awk '{gsub(/\.$/,""); print $0}'):5080 --idx $idx --replicas {{ .Values.zero.shardReplicaCount }}
+            else
+              exec dgraph zero --my=$(hostname -f | awk '{gsub(/\.$/,""); print $0}'):5080 --peer {{ template "dgraph.zero.fullname" . }}-0.{{ template "dgraph.zero.fullname" . }}-headless.${POD_NAMESPACE}.svc:5080 --idx $idx --replicas {{ .Values.zero.shardReplicaCount }}
+            fi
+        {{- end }}
         resources:
 {{ toYaml .Values.zero.resources | indent 10 }}
         {{- if .Values.zero.startupProbe.enabled }}

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -76,6 +76,10 @@ zero:
   ## Extra environment variables which will be appended to the env: definition for the container.
   extraEnvs: []
 
+  ## Alternative command line override
+  command:
+    override: []
+
   ## Configuration file for dgraph zero used as an alternative to command-line options
   ## Ref: https://dgraph.io/docs/deploy/#config
   configFile: {}
@@ -208,6 +212,10 @@ alpha:
     #   value: "XXXXXXXXXXXXXXXXXXXX"
     # - name: AWS_SECRET_ACCESS_KEY
     #   value: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+  ## Alternative command line override
+  command:
+    override: []
 
   ## Configuration file for dgraph alpha used as an alternative to command-line options
   ## Ref: https://dgraph.io/docs/deploy/#config

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -76,9 +76,8 @@ zero:
   ## Extra environment variables which will be appended to the env: definition for the container.
   extraEnvs: []
 
-  ## Alternative command line override
-  command:
-    override: []
+  ## Extra flags for command line flags in command
+  extraFlags: ""
 
   ## Configuration file for dgraph zero used as an alternative to command-line options
   ## Ref: https://dgraph.io/docs/deploy/#config
@@ -213,9 +212,8 @@ alpha:
     # - name: AWS_SECRET_ACCESS_KEY
     #   value: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
-  ## Alternative command line override
-  command:
-    override: []
+  ## Extra flags for command line flags in command
+  extraFlags: ""
 
   ## Configuration file for dgraph alpha used as an alternative to command-line options
   ## Ref: https://dgraph.io/docs/deploy/#config


### PR DESCRIPTION
This adds `extraFlags` option for customers to allow them to add additional command-line flags.

```
helm install test4 --set zero.extraFlags='--v=3 --trace=0.1' --set alpha.extraFlags='--v=3 --trace=0.1'  charts/dgraph/ 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/51)
<!-- Reviewable:end -->
