### PR TITLE
SUCCESS-137 service loadbalancer support

### DIFF
--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -81,6 +81,9 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `zero.service.type`                      | Zero service type                                                     | `ClusterIP`                                         |
 | `zero.service.annotations`               | Zero service annotations                                              | `{}`                                                |
 | `zero.service.publishNotReadyAddresses`  | publish address if pods not in ready state                            | `true`                                              |
+| `zero.service.loadBalancerIP`            | specify static IP address for LoadBalancer type                       | `""`                                                |
+| `zero.service.externalTrafficPolicy`     | route external traffic to node-local or cluster-wide endpoints        | `""`                                                |
+| `zero.service.loadBalancerSourceRanges`  | restrict CIDR IP addresses for a LoadBalancer type                    | `[]`                                                |
 | `zero.securityContext.enabled`           | Security context for zero nodes enabled                               | `false`                                             |
 | `zero.securityContext.fsGroup`           | Group id of the zero container                                        | `1001`                                              |
 | `zero.securityContext.runAsUser`         | User ID for the zero container                                        | `1001`                                              |
@@ -112,6 +115,9 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `alpha.service.type`                     | Alpha node service type                                               | `ClusterIP`                                         |
 | `alpha.service.annotations`              | Alpha service annotations                                             | `{}`                                                |
 | `alpha.service.publishNotReadyAddresses` | publish address if pods not in ready state                            | `true`                                              |
+| `alpha.service.loadBalancerIP`           | specify static IP address for LoadBalancer type                       | `""`                                                |
+| `alpha.service.externalTrafficPolicy`    | route external traffic to node-local or cluster-wide endpoints        | `""`                                                |
+| `alpha.service.loadBalancerSourceRanges` | restrict CIDR IP addresses for a LoadBalancer type                    | `[]`                                                |
 | `alpha.ingress.enabled`                  | Alpha Ingress resource enabled                                        | `false`                                             |
 | `alpha.ingress.hostname`                 | Alpha Ingress virtual hostname                                        | `nil`                                               |
 | `alpha.ingress.annotations`              | Alpha Ingress annotations                                             | `nil`                                               |
@@ -150,6 +156,9 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `ratel.extraEnvs`                        | Extra env vars                                                        | `[]`                                                |
 | `ratel.service.type`                     | Ratel service type                                                    | `ClusterIP`                                         |
 | `ratel.service.annotations`              | Ratel Service annotations                                             | `ClusterIP`                                         |
+| `ratel.service.loadBalancerIP`           | specify static IP address for LoadBalancer type                       | `""`                                                |
+| `ratel.service.externalTrafficPolicy`    | route external traffic to node-local or cluster-wide endpoints        | `""`                                                |
+| `ratel.service.loadBalancerSourceRanges` | restrict CIDR IP addresses for a LoadBalancer type                    | `[]`                                                |
 | `ratel.ingress.enabled`                  | Ratel Ingress resource enabled                                        | `false`                                             |
 | `ratel.ingress.hostname`                 | Ratel Ingress virtual hostname                                        | `nil`                                               |
 | `ratel.ingress.annotations`              | Ratel Ingress annotations                                             | `nil`                                               |

--- a/charts/dgraph/templates/alpha/svc.yaml
+++ b/charts/dgraph/templates/alpha/svc.yaml
@@ -15,12 +15,22 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.alpha.service.type }}
+  {{- if .Values.alpha.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.alpha.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.alpha.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.alpha.service.externalTrafficPolicy }}
+  {{- end }}
   ports:
   - port: 8080
     targetPort: 8080
     name: http-alpha
   - port: 9080
     name: grpc-alpha
+  {{- with .Values.alpha.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   publishNotReadyAddresses: {{ .Values.alpha.service.publishNotReadyAddresses }}
   selector:
     app: {{ template "dgraph.name" . }}

--- a/charts/dgraph/templates/ratel/svc.yaml
+++ b/charts/dgraph/templates/ratel/svc.yaml
@@ -15,10 +15,20 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.ratel.service.type }}
+  {{- if .Values.ratel.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.ratel.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.ratel.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.ratel.service.externalTrafficPolicy }}
+  {{- end }}
   ports:
   - port: 80
     targetPort: 8000
     name: http-ratel
+  {{- with .Values.ratel.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/zero/svc.yaml
+++ b/charts/dgraph/templates/zero/svc.yaml
@@ -15,6 +15,12 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.zero.service.type }}
+  {{- if .Values.zero.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.zero.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.zero.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.zero.externalTrafficPolicy }}
+  {{- end }}
   ports:
   - port: 5080
     targetPort: 5080
@@ -22,6 +28,10 @@ spec:
   - port: 6080
     targetPort: 6080
     name: http-zero
+  {{- with .Values.zero.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   publishNotReadyAddresses: {{ .Values.zero.service.publishNotReadyAddresses }}
   selector:
     app: {{ template "dgraph.name" . }}

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -90,6 +90,25 @@ zero:
     ## communicate to each other in order to enter a ready state.
     publishNotReadyAddresses: true
 
+    ## References:
+    ##  * General: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+    ##  * GKE: https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing#lb_subnet
+    ##  * AKS: https://docs.microsoft.com/en-us/azure/aks/ingress-static-ip
+    loadBalancerIP: ""
+
+    ## References:
+    ## * General: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+    ## * EKS: https://aws.amazon.com/blogs/opensource/network-load-balancer-support-in-kubernetes-1-9/
+    ## * AKS: https://docs.microsoft.com/en-us/azure/aks/load-balancer-standard#maintain-the-clients-ip-on-inbound-connections
+    externalTrafficPolicy: ""
+
+    ## References:
+    ## * General: https://kubernetes.io/docs/concepts/services-networking/service/#aws-nlb-support
+    ## * GKE: https://cloud.google.com/kubernetes-engine/docs/concepts/security-overview#filtering_load_balanced_traffic
+    ## * EKS: https://aws.amazon.com/premiumsupport/knowledge-center/eks-cidr-ip-address-loadbalancer/
+    ## * AKS: https://docs.microsoft.com/en-us/azure/aks/load-balancer-standard#restrict-inbound-traffic-to-specific-ip-ranges
+    loadBalancerSourceRanges: []
+
   ## dgraph Pod Security Context
   securityContext:
     enabled: false
@@ -186,7 +205,7 @@ alpha:
   ##
   replicaCount: 3
 
-  ## zero server pod termination grace period
+  ## alpha server pod termination grace period
   ##
   terminationGracePeriodSeconds: 600
 
@@ -224,6 +243,25 @@ alpha:
     ## StatefulSet pods will need to have addresses published in order to
     ## communicate to each other in order to enter a ready state.
     publishNotReadyAddresses: true
+
+    ## References:
+    ##  * General: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+    ##  * GKE: https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing#lb_subnet
+    ##  * AKS: https://docs.microsoft.com/en-us/azure/aks/ingress-static-ip
+    loadBalancerIP: ""
+
+    ## References:
+    ## * General: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+    ## * EKS: https://aws.amazon.com/blogs/opensource/network-load-balancer-support-in-kubernetes-1-9/
+    ## * AKS: https://docs.microsoft.com/en-us/azure/aks/load-balancer-standard#maintain-the-clients-ip-on-inbound-connections
+    externalTrafficPolicy: ""
+
+    ## References:
+    ## * General: https://kubernetes.io/docs/concepts/services-networking/service/#aws-nlb-support
+    ## * GKE: https://cloud.google.com/kubernetes-engine/docs/concepts/security-overview#filtering_load_balanced_traffic
+    ## * EKS: https://aws.amazon.com/premiumsupport/knowledge-center/eks-cidr-ip-address-loadbalancer/
+    ## * AKS: https://docs.microsoft.com/en-us/azure/aks/load-balancer-standard#restrict-inbound-traffic-to-specific-ip-ranges
+    loadBalancerSourceRanges: []
 
   ## alpha ingress resource configuration
   ## This requires an ingress controller to be installed into your k8s cluster
@@ -376,6 +414,26 @@ ratel:
   service:
     type: ClusterIP
     annotations: {}
+
+    ## References:
+    ##  * General: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+    ##  * GKE: https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing#lb_subnet
+    ##  * AKS: https://docs.microsoft.com/en-us/azure/aks/ingress-static-ip
+    loadBalancerIP: ""
+
+    ## References:
+    ## * General: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+    ## * EKS: https://aws.amazon.com/blogs/opensource/network-load-balancer-support-in-kubernetes-1-9/
+    ## * AKS: https://docs.microsoft.com/en-us/azure/aks/load-balancer-standard#maintain-the-clients-ip-on-inbound-connections
+    externalTrafficPolicy: ""
+
+    ## References:
+    ## * General: https://kubernetes.io/docs/concepts/services-networking/service/#aws-nlb-support
+    ## * GKE: https://cloud.google.com/kubernetes-engine/docs/concepts/security-overview#filtering_load_balanced_traffic
+    ## * EKS: https://aws.amazon.com/premiumsupport/knowledge-center/eks-cidr-ip-address-loadbalancer/
+    ## * AKS: https://docs.microsoft.com/en-us/azure/aks/load-balancer-standard#restrict-inbound-traffic-to-specific-ip-ranges
+    loadBalancerSourceRanges: []
+
 
   ## ratel ingress resource configuration
   ## This requires an ingress controller to be installed into your k8s cluster


### PR DESCRIPTION
Support for these properties in Ratel, Alpha, Zero:
    * `loadBalancerIP`
    * `externalTrafficPolicy`
    * `loadBalancerSourceRanges`

Testing:

```bash
helm install test --dry-run --debug --values values.yaml ~/charts/charts/dgraph/
```

```yaml
# values.yaml
alpha:
  service:
    loadBalancerIP: 40.121.183.53
    externalTrafficPolicy: Local
    loadBalancerSourceRanges:
      - "143.232.0.0/16"

zero:
  service:
    type: LoadBalancer
    loadBalancerIP: 40.121.183.52
    externalTrafficPolicy: Local
    loadBalancerSourceRanges:
      - "143.231.0.0/16"

ratel:
  service:
    loadBalancerIP: 40.121.183.54
    externalTrafficPolicy: Cluster
    loadBalancerSourceRanges:
      - "143.233.0.0/16"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/52)
<!-- Reviewable:end -->
