### PR TITLE
add schedulerName option

### DIFF
--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -62,6 +62,9 @@ spec:
         release: {{ .Release.Name }}
         component: {{ .Values.alpha.name }}
     spec:
+      {{- if .Values.alpha.schedulerName }}
+      schedulerName: {{ .Values.alpha.schedulerName }}
+      {{- end }}
       {{- if or (eq .Values.alpha.antiAffinity "hard") (eq .Values.alpha.antiAffinity "soft") .Values.alpha.nodeAffinity }}
       affinity:
       {{- end }}

--- a/charts/dgraph/templates/backups/cronjob-full.yaml
+++ b/charts/dgraph/templates/backups/cronjob-full.yaml
@@ -28,6 +28,9 @@ spec:
     spec:
       template:
         spec:
+          {{- if .Values.backups.schedulerName }}
+          schedulerName: {{ .Values.backups.schedulerName }}
+          {{- end }}
           containers:
           - name: {{ template "dgraph.backups.fullname" . }}-full
             image: {{ template "dgraph.backups.image" . }}

--- a/charts/dgraph/templates/backups/cronjob-inc.yaml
+++ b/charts/dgraph/templates/backups/cronjob-inc.yaml
@@ -28,6 +28,9 @@ spec:
     spec:
       template:
         spec:
+          {{- if .Values.backups.schedulerName }}
+          schedulerName: {{ .Values.backups.schedulerName }}
+          {{- end }}
           containers:
           - name: {{ template "dgraph.backups.fullname" . }}-inc
             image: {{ template "dgraph.backups.image" . }}

--- a/charts/dgraph/templates/ratel/deployment.yaml
+++ b/charts/dgraph/templates/ratel/deployment.yaml
@@ -25,6 +25,9 @@ spec:
         component: {{ .Values.ratel.name }}
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.ratel.schedulerName }}
+      schedulerName: {{ .Values.ratel.schedulerName }}
+      {{- end }}
       {{- if .Values.ratel.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.ratel.securityContext.fsGroup }}

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -41,6 +41,9 @@ spec:
         release: {{ .Release.Name }}
         component: {{ .Values.zero.name }}
     spec:
+      {{- if .Values.zero.schedulerName }}
+      schedulerName: {{ .Values.zero.schedulerName }}
+      {{- end }}
       {{- if or (eq .Values.zero.antiAffinity "hard") (eq .Values.zero.antiAffinity "soft") .Values.zero.nodeAffinity }}
       affinity:
       {{- end }}

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -38,6 +38,11 @@ zero:
   ##
   updateStrategy: RollingUpdate
 
+  ## Scheduler name
+  ## https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  # schedulerName: stork
+
   ## Partition update strategy
   ## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
   ##
@@ -193,6 +198,11 @@ alpha:
   ## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets
   ##
   updateStrategy: RollingUpdate
+
+  ## Scheduler name
+  ## https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  # schedulerName: stork
 
   ## Partition update strategy
   ## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
@@ -404,6 +414,11 @@ alpha:
 ratel:
   name: ratel
 
+  ## Scheduler name
+  ## https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  # schedulerName: stork
+
   ## Enable Ratel service
   enabled: true
 
@@ -494,6 +509,12 @@ ratel:
 ## ref: https://dgraph.io/docs/enterprise-features/binary-backups/
 ##
 backups:
+
+  ## Scheduler name
+  ## https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  # schedulerName: stork
+
   name: backups
   admin:
     ## backup user and password that is a member of 'guardians'group used to


### PR DESCRIPTION
For people having their own storage solution (i.e. portworx) for on-premise kubernetes cluster like us, we need to be able to specify a scheduler name in order to use the dedicated storage nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/53)
<!-- Reviewable:end -->
