### PR TITLE
Fix: Change default restartPolicy to Never

### DIFF
--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -193,9 +193,11 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `backups.full.enabled`                   | Enable full backups cronjob                                           | `false`                                             |
 | `backups.full.debug`                     | Enable `set -x` for cron shell script                                 | `false`                                             |
 | `backups.full.schedule`                  | Cronjob schedule                                                      | `"0 * * * *"`                                       |
+| `backups.full.restartPolicy`             | Restart policy                                                        | `Never`                                             |
 | `backups.incremental.enabled`            | Enable incremental backups cronjob                                    | `false`                                             |
 | `backups.incremental.debug`              | Enable `set -x` for cron shell script                                 | `false`                                             |
 | `backups.incremental.schedule`           | Cronjob schedule                                                      | `"0 1-23 * * *"`                                    |
+| `backups.incremental.restartPolicy`      | Restart policy                                                        | `Never`                                             |
 | `backups.destination`                    | Destination - file path, s3://, minio:                                | `/dgraph/backups`                                   |
 | `backups.subpath`                        | Specify subpath where full + related incremental backups are stored   | `dgraph_$(date +%Y%m%d)`                            |
 | `backups.minioSecure`                    | Set to true if Minio server specified in minio:// supports TLS        | `false`                                             |

--- a/charts/dgraph/templates/backups/cronjob-full.yaml
+++ b/charts/dgraph/templates/backups/cronjob-full.yaml
@@ -100,7 +100,7 @@ spec:
               value: /dgraph/tls/client.{{ .Values.backups.admin.tls_client }}.key
             {{- end }}
             {{- end }}
-          restartPolicy: OnFailure
+          restartPolicy: {{ .Values.backups.incremental.restartPolicy }}
           volumes:
           - name: backup-config-volume
             configMap:

--- a/charts/dgraph/templates/backups/cronjob-inc.yaml
+++ b/charts/dgraph/templates/backups/cronjob-inc.yaml
@@ -100,7 +100,7 @@ spec:
               value: /dgraph/tls/client.{{ .Values.backups.admin.tls_client }}.key
             {{- end }}
             {{- end }}
-          restartPolicy: OnFailure
+          restartPolicy: {{ .Values.backups.incremental.restartPolicy }}
           volumes:
           - name: backup-config-volume
             configMap:

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -538,6 +538,8 @@ backups:
     ## full backup schedule
     ## 12AM server time
     schedule: "0 * * * *"
+    ## restart policy
+    restartPolicy: Never
   incremental:
     enabled: false
     ## enable bash debugging (set -x)
@@ -545,6 +547,8 @@ backups:
     ## incremental backup schedule
     ## every hour, except 12AM serer time
     schedule: "0 1-23 * * *"
+    ## restart policy
+    restartPolicy: Never
   ## destination is file path, s3, or minio
   ## examples:
   ##   /dgraph/backups


### PR DESCRIPTION
Currently the default restartPolicy for backup jobs is OnFailure.  This means it will continiously retry until success.  If for some reason the job will always fail, e.g. enterprise license has expired, then the job will both never fail and never succeed.  This makes it difficult to debug.

This change makes the job fail when it fails, as is consistent with typical cron use cases.  The operator will see something like:

```
dev-dgraph-backups-full-1607721900-726gm   0/1     Completed   0          16m
dev-dgraph-backups-full-1607722200-qj62g   0/1     Completed   0          11m
dev-dgraph-backups-full-1607722500-6p54h   0/1     Completed   0          6m8s
dev-dgraph-backups-full-1607722800-5blxs   0/1     Error       0          55s
dev-dgraph-backups-full-1607722800-8bbp5   0/1     Error       0          65s
dev-dgraph-backups-full-1607722800-gjr2k   0/1     Error       0          35s
dev-dgraph-backups-full-1607722800-lwngr   0/1     Error       0          67s
```

For there, the operator can take one of these pods that has an error, and extract the error that occurred:

```bash
$ kubectl logs dev-dgraph-backups-full-1607722800-5blxs | tail -1
ERROR: resolving backup failed because you must enable enterprise features first. Supply the appropriate license file to Dgraph Zero using the HTTP endpoint.
```

Additionally, metrics from Prometheus can show that an error has occurred:

Element | Value
-- | --
kube_job_status_failed{container="kube-state-metrics",endpoint="http",instance="192.168.30.104:8080",job="kube-state-metrics",job_name="dev-dgraph-backups-full-1607721900",namespace="default",pod="prometheus-kube-state-metrics-6df5d44568-xbzdn",service="prometheus-kube-state-metrics"} | 0
kube_job_status_failed{container="kube-state-metrics",endpoint="http",instance="192.168.30.104:8080",job="kube-state-metrics",job_name="dev-dgraph-backups-full-1607722200",namespace="default",pod="prometheus-kube-state-metrics-6df5d44568-xbzdn",service="prometheus-kube-state-metrics"} | 0
kube_job_status_failed{container="kube-state-metrics",endpoint="http",instance="192.168.30.104:8080",job="kube-state-metrics",job_name="dev-dgraph-backups-full-1607722500",namespace="default",pod="prometheus-kube-state-metrics-6df5d44568-xbzdn",service="prometheus-kube-state-metrics"} | 0
kube_job_status_failed{container="kube-state-metrics",endpoint="http",instance="192.168.30.104:8080",job="kube-state-metrics",job_name="dev-dgraph-backups-full-1607722800",namespace="default",pod="prometheus-kube-state-metrics-6df5d44568-xbzdn",service="prometheus-kube-state-metrics"} | 3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/55)
<!-- Reviewable:end -->
