### PR TITLE
metadata labels utilized for backup monitoring

### DIFF
--- a/charts/dgraph/templates/backups/cronjob-full.yaml
+++ b/charts/dgraph/templates/backups/cronjob-full.yaml
@@ -25,8 +25,14 @@ metadata:
 spec:
   schedule: "{{ .Values.backups.full.schedule }}"
   jobTemplate:
+    metadata:
+      labels:
+        cronjob: {{ template "dgraph.backups.fullname" . }}-full
     spec:
       template:
+        metadata:
+          labels:
+            cronjob: {{ template "dgraph.backups.fullname" . }}-full
         spec:
           containers:
           - name: {{ template "dgraph.backups.fullname" . }}-full

--- a/charts/dgraph/templates/backups/cronjob-inc.yaml
+++ b/charts/dgraph/templates/backups/cronjob-inc.yaml
@@ -25,8 +25,14 @@ metadata:
 spec:
   schedule: "{{ .Values.backups.incremental.schedule }}"
   jobTemplate:
+    metadata:
+      labels:
+        cronjob: {{ template "dgraph.backups.fullname" . }}-inc
     spec:
       template:
+        metadata:
+          labels:
+            cronjob: {{ template "dgraph.backups.fullname" . }}-inc
         spec:
           containers:
           - name: {{ template "dgraph.backups.fullname" . }}-inc


### PR DESCRIPTION
This updates Kubernetes CronJobs to add new metadata that is useful for monitoring.  This will create a label of `cronjob` for the Kubernetes Job and corresponding Kubernetes Pod with the value that matches the Kubernetes CronJob metadata name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/56)
<!-- Reviewable:end -->
