### PR TITLE
Fixes parse errors when linting

### DIFF
--- a/charts/dgraph/templates/_helpers.tpl
+++ b/charts/dgraph/templates/_helpers.tpl
@@ -70,7 +70,7 @@ Return empty string if minio keys are not defined
 {{- $minioEnabled := "" -}}
 {{- $backupsEnabled := or .Values.backups.full.enabled .Values.backups.incremental.enabled }}
 {{- if $backupsEnabled -}}
-  {{- if .Values.backups.keys  -}}
+  {{- if .Values.backups.keys -}}
     {{- if .Values.backups.keys.minio -}}
       {{- if and .Values.backups.keys.minio.access .Values.backups.keys.minio.secret -}}
         {{- $minioEnabled = true -}}
@@ -88,7 +88,7 @@ Return empty string if s3 keys are not defined
 {{- $s3Enabled := "" -}}
 {{- $backupsEnabled := or .Values.backups.full.enabled .Values.backups.incremental.enabled }}
 {{- if $backupsEnabled -}}
-  {{- if .Values.backups.keys  -}}
+  {{- if .Values.backups.keys -}}
     {{- if .Values.backups.keys.s3 -}}
       {{- if and .Values.backups.keys.s3.access .Values.backups.keys.s3.secret -}}
         {{- $s3Enabled = true -}}


### PR DESCRIPTION
It happens when running a Jenkins X command `jx step helm build` which will run `helm lint --set tags.jx-lint=true --set global.jxLint=true --set-string global.jxTypeEnv=lint --values values.yaml`

```
==> Linting .
[ERROR] templates/: parse error in "env/charts/dgraph2/templates/_helpers.tpl": template: env/charts/dgraph2/templates/_helpers.tpl:73: illegal number syntax: "-"
```

```
==> Linting .
[ERROR] templates/: parse error in "env/charts/dgraph2/templates/_helpers.tpl": template: env/charts/dgraph2/templates/_helpers.tpl:91: illegal number syntax: "-"
```

```
~:> jx version
Version        2.1.114
Commit         e2198a9
Build date     2020-07-23T15:20:47Z
Go version     1.13.8
Git tree state clean
```

```
~:> helm version --client
Client: &version.Version{SemVer:"v2.17.0", GitCommit:"a690bad98af45b015bd3da1a41f6218b1a451dbe", GitTreeState:"clean"}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/59)
<!-- Reviewable:end -->
