### PR TITLE
fix: Configure no-persistence emptyDir correctly.

### DIFF
--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -259,8 +259,12 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.alpha.terminationGracePeriodSeconds }}
       volumes:
       - name: datadir
+      {{- if .Values.alpha.persistence.enabled }}
         persistentVolumeClaim:
           claimName: datadir
+      {{- else }}
+        emptyDir: {}
+      {{- end }}
       {{- if and $backupsEnabled (or $hasS3Keys $hasMinioKeys) }}
       - name: backup-secret-volume
         secret:
@@ -318,7 +322,4 @@ spec:
         storageClassName: {{ .Values.alpha.persistence.storageClass | quote }}
       {{- end -}}
       {{- end -}}
-{{- else }}
-        - name: datadir
-          emptyDir: {}
 {{- end }}

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -187,9 +187,13 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.zero.terminationGracePeriodSeconds }}
       volumes:
       - name: datadir
+      {{- if .Values.zero.persistence.enabled }}
         persistentVolumeClaim:
           claimName: datadir
-     {{- if .Values.zero.configFile }}
+      {{- else }}
+        emptyDir: {}
+      {{- end }}
+      {{- if .Values.zero.configFile }}
       - name: config-volume
         configMap:
           name: {{ template "dgraph.zero.fullname" . }}-config
@@ -223,7 +227,4 @@ spec:
         storageClassName: {{ .Values.zero.persistence.storageClass | quote }}
       {{- end -}}
       {{- end -}}
-{{- else }}
-        - name: datadir
-          emptyDir: {}
 {{- end }}


### PR DESCRIPTION
The helm installation fails when persistence is disabled. e.g., setting either
alpha.persistence.enabled or zero.persistence.enabled to false.

    $ helm install dev dgraph/dgraph --set alpha.persistence.enabled=false,zero.persistence.enabled=false
    Error: YAML parse error on dgraph/templates/alpha/statefulset.yaml: error converting YAML to JSON: yaml: line 88: did not find expected key

The cause for this error can be seen when rendering the template. The emptyDir
config gets mangled with the configMap:

    - name: config-volume
      configMap:
        name: dev-dgraph-alpha-config
      - name: datadir
        emptyDir: {}
    Error: YAML parse error on dgraph/templates/alpha/statefulset.yaml: error converting YAML to JSON: yaml: line 88: did not find expected key
    helm.go:81: [debug] error converting YAML to JSON: yaml: line 88: did not find expected key

This change sets the emptyDir config in the volumes section for datadir.

Resolves https://discuss.dgraph.io/t/helm-chart-deployment-fails-when-persistence-is-disabled/12240

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/60)
<!-- Reviewable:end -->
