### PR TITLE
docs: Fix typo in PUBLISH docs.

### DIFF
--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -14,7 +14,7 @@ to verify that the chart is well-formed:
 
 ```bash
 helm lint charts/dgraph
-helm ling charts/dgraph-lambda
+helm lint charts/dgraph-lambda
 ```
 
 ### Create the Helm chart package


### PR DESCRIPTION
Fix typo for `helm lint` command.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/61)
<!-- Reviewable:end -->
