### PR TITLE
fix(dgraph) - fix backup secrets where some values can cause saving secret to fail

### DIFF
--- a/charts/dgraph/templates/backups/secrets.yaml
+++ b/charts/dgraph/templates/backups/secrets.yaml
@@ -19,17 +19,17 @@ metadata:
 type: Opaque
 data:
   {{- if .Values.alpha.acl.enabled }}
-  backup_admin_password: {{ .Values.backups.admin.password | b64enc | quote }}
+  backup_admin_password: {{ .Values.backups.admin.password | toString | b64enc | quote }}
   {{- end }}
   {{- if .Values.backups.admin.auth_token }}
-  backup_auth_token: {{ .Values.backups.admin.auth_token | b64enc | quote }}
+  backup_auth_token: {{ .Values.backups.admin.auth_token | toString | b64enc | quote }}
   {{- end }}
   {{- if $hasS3Keys }}
-  s3_access_key: {{ .Values.backups.keys.s3.access | b64enc | quote }}
-  s3_secret_key: {{ .Values.backups.keys.s3.secret | b64enc | quote }}
+  s3_access_key: {{ .Values.backups.keys.s3.access | toString | b64enc | quote }}
+  s3_secret_key: {{ .Values.backups.keys.s3.secret | toString | b64enc | quote }}
   {{- end }}
   {{- if $hasMinioKeys }}
-  minio_access_key: {{ .Values.backups.keys.minio.access | b64enc | quote }}
-  minio_secret_key: {{ .Values.backups.keys.minio.secret | b64enc | quote }}
+  minio_access_key: {{ .Values.backups.keys.minio.access | toString | b64enc | quote }}
+  minio_secret_key: {{ .Values.backups.keys.minio.secret | toString | b64enc | quote }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Fix issue where helm chart would fail if secret value was not of type string.  This affects:
* `backup_admin_password` - password for groot
* `backup_auth_token` - poor man's auth token for non-enterprise
* `s3_access_key` + `s3_secret_key` - AWS IAM credentials
* `minio_access_key` + `minio_secret_key` - MinIO credentials

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/62)
<!-- Reviewable:end -->
