### PR TITLE
feature(dgraph) version bump to dgraph v20.11.3

### DIFF
--- a/charts/dgraph/Chart.yaml
+++ b/charts/dgraph/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: dgraph
-version: 0.0.15
-appVersion: v20.11.1
+version: 0.0.16
+appVersion: v20.11.3
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:
 - dgraph

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -61,7 +61,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | ---------------------------------------- | --------------------------------------------------------------------- | --------------------------------------------------- |
 | `image.registry`                         | Container registry name                                               | `docker.io`                                         |
 | `image.repository`                       | Container image name                                                  | `dgraph/dgraph`                                     |
-| `image.tag`                              | Container image tag                                                   | `v20.11.1`                                          |
+| `image.tag`                              | Container image tag                                                   | `v20.11.3`                                          |
 | `image.pullPolicy`                       | Container pull policy                                                 | `IfNotPresent`                                      |
 | `nameOverride`                           | Deployment name override (will append the release name)               | `nil`                                               |
 | `fullnameOverride`                       | Deployment full name override (the release name is ignored)           | `nil`                                               |
@@ -151,7 +151,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `alpha.initContainers.init.enabled`      | Alpha initContainer enabled                                           | `true`                                              |
 | `alpha.initContainers.init.image.registry`   | Alpha initContainer registry name                                 | `docker.io`                                         |
 | `alpha.initContainers.init.image.repository` | Alpha initContainer image name                                    | `dgraph/dgraph`                                     |
-| `alpha.initContainers.init.image.tag`        | Alpha initContainer image tag                                     | `v20.11.1`                                          |
+| `alpha.initContainers.init.image.tag`        | Alpha initContainer image tag                                     | `v20.11.3`                                          |
 | `alpha.initContainers.init.image.pullPolicy` | Alpha initContainer pull policy                                   | `IfNotPresent`                                      |
 | `alpha.initContainers.init.command`      | Alpha initContainer command line to execute                           | See `values.yaml` for defaults                      |
 | `ratel.name`                             | Ratel component name                                                  | `ratel`                                             |
@@ -184,7 +184,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `backups.admin.auth_token`               | Auth Token                                                            | `nil`                                               |
 | `backups.image.registry`                 | Container registry name                                               | `docker.io`                                         |
 | `backups.image.repository`               | Container image name                                                  | `dgraph/dgraph`                                     |
-| `backups.image.tag`                      | Container image tag                                                   | `v20.11.1`                                          |
+| `backups.image.tag`                      | Container image tag                                                   | `v20.11.3`                                          |
 | `backups.image.pullPolicy`               | Container pull policy                                                 | `IfNotPresent`                                      |
 | `backups.nfs.enabled`                    | Enable mounted NFS volume for backups                                 | `false`                                             |
 | `backups.nfs.server`                     | NFS Server DNS or IP address                                          | `nil`                                               |
@@ -313,7 +313,7 @@ curl --silent \
 
 ## Securing internal communication with mutual TLS
 
-Both Alpha and Zero can now use secure internal communication with Mutual TLS starting with Dgraph `v20.11.1`. As an example, see [zero-tls-config.yaml](https://github.com/dgraph-io/charts/tree/master/charts/dgraph/example_values/zero-tls-config.yaml) for an example configuration.
+Both Alpha and Zero can now use secure internal communication with Mutual TLS starting with Dgraph `v20.11.3`. As an example, see [zero-tls-config.yaml](https://github.com/dgraph-io/charts/tree/master/charts/dgraph/example_values/zero-tls-config.yaml) for an example configuration.
 
 ### Securing internal Communication mutual TLS example
 

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -10,7 +10,7 @@
 image: &image
   registry: docker.io
   repository: dgraph/dgraph
-  tag: v20.11.1
+  tag: v20.11.3
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
This updates dgraph image tag form `v20.11.1` to `v20.11.3`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/63)
<!-- Reviewable:end -->
