### PR TITLE
feature(dgraph) - forward support for v21.03 raft index superflag option

### DIFF
--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -10,6 +10,14 @@
 
   {{- printf "%s-%d.%s-headless.${POD_NAMESPACE}.svc%s:5080" $zeroFullName 0 $zeroFullName $domainSuffix -}}
 {{- end -}}
+{{- /* Superflag (v21.03.0) support and legacy flags */}}
+{{- define "raft_index_flag" -}}
+  {{- if (eq .Values.image.tag "bugbusters") -}}
+    {{- printf "--raft idx=" -}}
+  {{- else -}}
+    {{- printf "--idx " -}}
+  {{- end -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -130,9 +138,9 @@ spec:
               ordinal=${BASH_REMATCH[1]}
               idx=$(($ordinal + 1))
               if [[ $ordinal -eq 0 ]]; then
-                exec dgraph zero --my=$(hostname -f | awk '{gsub(/\.$/,""); print $0}'):5080 --idx $idx --replicas {{ .Values.zero.shardReplicaCount }} {{ .Values.zero.extraFlags }}
+                exec dgraph zero --my=$(hostname -f | awk '{gsub(/\.$/,""); print $0}'):5080 {{ template "raft_index_flag" . }}$idx --replicas {{ .Values.zero.shardReplicaCount }} {{ .Values.zero.extraFlags }}
               else
-                exec dgraph zero --my=$(hostname -f | awk '{gsub(/\.$/,""); print $0}'):5080 --peer {{ template "peer_zero" . }} --idx $idx --replicas {{ .Values.zero.shardReplicaCount }} {{ .Values.zero.extraFlags }}
+                exec dgraph zero --my=$(hostname -f | awk '{gsub(/\.$/,""); print $0}'):5080 --peer {{ template "peer_zero" . }} {{ template "raft_index_flag" . }}$idx --replicas {{ .Values.zero.shardReplicaCount }} {{ .Values.zero.extraFlags }}
               fi
         resources:
 {{ toYaml .Values.zero.resources | indent 10 }}

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -12,7 +12,8 @@
 {{- end -}}
 {{- /* Superflag (v21.03.0) support and legacy flags */}}
 {{- define "raft_index_flag" -}}
-  {{- if (eq .Values.image.tag "bugbusters") -}}
+  {{- $safeVersion := include "dgraph.version" . -}}
+  {{- if semverCompare ">= 21.03.0" $safeVersion -}}
     {{- printf "--raft idx=" -}}
   {{- else -}}
     {{- printf "--idx " -}}


### PR DESCRIPTION
This updates the new superflag format for the raft index.  Both earlier versions with `--idx <num>` and future version with `--raft idx=<num> are support.

Other dgraph flags/superflags are at user discretion through `zero.extraEnvs`, `zero.extraFlags`, `zero.configFile`, `alpha.extraEnvs`, `alpha.extraFlags`, or `alpha.configFile`, and so no changes needed for this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/64)
<!-- Reviewable:end -->
