### PR TITLE
fix: update image tag to dgraph/dgraph:v21.03.1 and dgraph/ratel:v21.03.0

### DIFF
--- a/charts/dgraph/Chart.yaml
+++ b/charts/dgraph/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: dgraph
-version: 0.0.17
-appVersion: v21.03.0
+version: 0.0.18
+appVersion: v21.03.1
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:
 - dgraph

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -61,7 +61,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | ---------------------------------------- | --------------------------------------------------------------------- | --------------------------------------------------- |
 | `image.registry`                         | Container registry name                                               | `docker.io`                                         |
 | `image.repository`                       | Container image name                                                  | `dgraph/dgraph`                                     |
-| `image.tag`                              | Container image tag                                                   | `v21.03.0`                                          |
+| `image.tag`                              | Container image tag                                                   | `v21.03.1`                                          |
 | `image.pullPolicy`                       | Container pull policy                                                 | `IfNotPresent`                                      |
 | `nameOverride`                           | Deployment name override (will append the release name)               | `nil`                                               |
 | `fullnameOverride`                       | Deployment full name override (the release name is ignored)           | `nil`                                               |
@@ -157,8 +157,8 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `ratel.name`                             | Ratel component name                                                  | `ratel`                                             |
 | `ratel.enabled`                          | Ratel service enabled or disabled                                     | `false`                                             |
 | `ratel.image.registry`                   | Container registry name                                               | `docker.io`                                         |
-| `ratel.image.repository`                 | Container image name                                                  | `dgraph/dgraph`                                     |
-| `ratel.image.tag`                        | Container image tag                                                   | `v20.11.3`                                          |
+| `ratel.image.repository`                 | Container image name                                                  | `dgraph/ratel`                                      |
+| `ratel.image.tag`                        | Container image tag                                                   | `v21.03.0`                                          |
 | `ratel.image.pullPolicy`                 | Container pull policy                                                 | `IfNotPresent`                                      |
 | `ratel.schedulerName`                    | Configure an explicit scheduler                                       | `nil`                                               |
 | `ratel.replicaCount`                     | Number of ratel nodes                                                 | `1`                                                 |

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -10,7 +10,7 @@
 image: &image
   registry: docker.io
   repository: dgraph/dgraph
-  tag: v21.03.0
+  tag: v21.03.1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -426,8 +426,8 @@ ratel:
   ##  The image dgraph/dgraph:v21.11.3 is last known version that has Ratel.
   image:
     registry: docker.io
-    repository: dgraph/dgraph
-    tag: v20.11.3
+    repository: dgraph/ratel
+    tag: v21.03.1
 
   ## Scheduler name
   ## https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/


### PR DESCRIPTION
This update contains the following:

* update ratel image to now use dgraph/ratel, as ratel is no longer support in dgraph/dgraph image.
* version bump dgraph/dgraph image to v21.03.1 
* chart version upgrade for future release

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/69)
<!-- Reviewable:end -->
