### PR TITLE
add template annotation support for sts/deploy to allow linkerd or ot…

### DIFF
--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -66,6 +66,8 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `nameOverride`                           | Deployment name override (will append the release name)               | `nil`                                               |
 | `fullnameOverride`                       | Deployment full name override (the release name is ignored)           | `nil`                                               |
 | `zero.name`                              | Zero component name                                                   | `zero`                                              |
+| `zero.metrics.enabled`                   | Add annotations for Prometheus metric scraping                        | `true`                                              |
+| `zero.extraAnnotations`                  | Specify annotations for template metadata                             | `{}`                                                |
 | `zero.updateStrategy`                    | Strategy for upgrading zero nodes                                     | `RollingUpdate`                                     |
 | `zero.schedulerName`                     | Configure an explicit scheduler                                       | `nil`                                               |
 | `zero.monitorLabel`                      | Monitor label for zero, used by prometheus.                           | `zero-dgraph-io`                                    |
@@ -103,6 +105,8 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `zero.customLivenessProbe`               | Zero custom liveness probes (if `zero.livenessProbe` not enabled)     | `{}`                                                |
 | `zero.customReadinessProbe`              | Zero custom readiness probes  (if `zero.readinessProbe` not enabled)  | `{}`                                                |
 | `alpha.name`                             | Alpha component name                                                  | `alpha`                                             |
+| `alpha.metrics.enabled`                  | Add annotations for Prometheus metric scraping                        | `true`                                              |
+| `alpha.extraAnnotations`                 | Specify annotations for template metadata                             | `{}`                                                |
 | `alpha.monitorLabel`                     | Monitor label for alpha, used by prometheus.                          | `alpha-dgraph-io`                                   |
 | `alpha.updateStrategy`                   | Strategy for upgrading alpha nodes                                    | `RollingUpdate`                                     |
 | `alpha.schedulerName`                    | Configure an explicit scheduler                                       | `nil`                                               |
@@ -156,6 +160,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `alpha.initContainers.init.command`      | Alpha initContainer command line to execute                           | See `values.yaml` for defaults                      |
 | `ratel.name`                             | Ratel component name                                                  | `ratel`                                             |
 | `ratel.enabled`                          | Ratel service enabled or disabled                                     | `false`                                             |
+| `ratel.extraAnnotations`                 | Specify annotations for template metadata                             | `{}`                                                |
 | `ratel.image.registry`                   | Container registry name                                               | `docker.io`                                         |
 | `ratel.image.repository`                 | Container image name                                                  | `dgraph/ratel`                                      |
 | `ratel.image.tag`                        | Container image tag                                                   | `v21.03.0`                                          |

--- a/charts/dgraph/example_values/linkerd.yaml
+++ b/charts/dgraph/example_values/linkerd.yaml
@@ -1,0 +1,10 @@
+alpha:
+  extraAnnotations:
+    config.linkerd.io/skip-inbound-ports: 7080
+    config.linkerd.io/skip-outbound-ports: 7080
+    linkerd.io/inject: enabled
+zero:
+  extraAnnotations:
+    config.linkerd.io/skip-inbound-ports: 5080
+    config.linkerd.io/skip-outbound-ports: 5080
+    linkerd.io/inject: enabled

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -57,11 +57,16 @@ spec:
   template:
     metadata:
       name: {{ template "dgraph.alpha.fullname" . }}
-      {{- if .Values.alpha.metrics.enabled }}
+      {{- if or .Values.alpha.metrics.enabled .Values.alpha.extraAnnotations }}
       annotations:
+        {{- if .Values.alpha.metrics.enabled }}
         prometheus.io/path: /debug/prometheus_metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
+        {{- end }}
+        {{- with .Values.alpha.extraAnnotations }}
+{{- toYaml . | trimSuffix "\n" | nindent 8 }}
+        {{- end }}
       {{- end }}
       labels:
         app: {{ template "dgraph.name" . }}

--- a/charts/dgraph/templates/ratel/deployment.yaml
+++ b/charts/dgraph/templates/ratel/deployment.yaml
@@ -19,6 +19,12 @@ spec:
   replicas: {{ .Values.ratel.replicaCount }}
   template:
     metadata:
+      {{- if .Values.ratel.extraAnnotations }}
+      annotations:
+        {{- with .Values.ratel.extraAnnotations }}
+{{- toYaml . | trimSuffix "\n" | nindent 8 }}
+        {{- end }}
+      {{- end }}
       labels:
         app: {{ template "dgraph.name" . }}
         chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -50,11 +50,16 @@ spec:
   template:
     metadata:
       name: {{ template "dgraph.zero.fullname" . }}
-      {{- if .Values.zero.metrics.enabled }}
+      {{- if or .Values.zero.metrics.enabled .Values.zero.extraAnnotations }}
       annotations:
+        {{- if .Values.zero.metrics.enabled }}
         prometheus.io/path: /debug/prometheus_metrics
         prometheus.io/port: "6080"
         prometheus.io/scrape: "true"
+        {{- end }}
+        {{- with .Values.zero.extraAnnotations }}
+{{- toYaml . | trimSuffix "\n" | nindent 8 }}
+        {{- end }}
       {{- end }}
       labels:
         app: {{ template "dgraph.name" . }}

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -32,6 +32,10 @@ zero:
   name: zero
   metrics:
     enabled: true
+
+  ## StatefulSet spec.template.metadata.annotations
+  extraAnnotations: {}
+
   monitorLabel: zero-dgraph-io
   ## StatefulSet controller supports automated updates. There are two valid update strategies: RollingUpdate and OnDelete
   ## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets
@@ -201,6 +205,10 @@ alpha:
   name: alpha
   metrics:
     enabled: true
+
+  ## StatefulSet spec.template.metadata.annotations
+  extraAnnotations: {}
+
   monitorLabel: alpha-dgraph-io
   ## StatefulSet controller supports automated updates. There are two valid update strategies: RollingUpdate and OnDelete
   ## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets
@@ -421,6 +429,9 @@ ratel:
   name: ratel
   ## Disable Ratel service
   enabled: false
+
+  ## Deployment spec.template.metadata.annotations
+  extraAnnotations: {}
 
   ## NOTE: Ratel is no longer included in dgraph image since dgraph/dgraph:v21.03.0
   ##  The image dgraph/dgraph:v21.11.3 is last known version that has Ratel.


### PR DESCRIPTION
This adds support for deploy and sts template annotations.  This will allow for annotations that allow services to inject side-cars containers, such as linkerd proxy-injection.

This changes were added:

*  ratel.extraAnnotations for deploy template annotations
* alpha.extraAnnotations and zero.extraAnnotations for sts template annotations
* updated README for new value and missing metrics.enabled value
* provided example linkerd.yaml 

This was tested with the following values file:

```yaml
alpha:
  extraAnnotations:
    config.linkerd.io/skip-inbound-ports: 7080
    config.linkerd.io/skip-outbound-ports: 7080
    linkerd.io/inject: enabled
zero:
  extraAnnotations:
    config.linkerd.io/skip-inbound-ports: 5080
    config.linkerd.io/skip-outbound-ports: 5080
    linkerd.io/inject: enabled
ratel:
  enabled: true
  extraAnnotations:
     linkerd.io/inject: enabled
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/71)
<!-- Reviewable:end -->
