### PR TITLE
Fix ingress for K8s v1.18

### DIFF
--- a/charts/dgraph/Chart.yaml
+++ b/charts/dgraph/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: dgraph
-version: 0.0.18
-appVersion: v21.03.1
+version: 0.0.19
+appVersion: v21.12.0
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:
 - dgraph

--- a/charts/dgraph/example_values/ingress/ingress-nginx-grpc.yaml
+++ b/charts/dgraph/example_values/ingress/ingress-nginx-grpc.yaml
@@ -14,8 +14,8 @@
 global:
   ingress:
     enabled: true
+    ingressClassName: nginx
     annotations:
-      kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
       nginx.ingress.kubernetes.io/backend-protocol: HTTP
       cert-manager.io/cluster-issuer: letsencrypt-prod
@@ -30,8 +30,8 @@ global:
     alpha_hostname: alpha.example.com
   ingress_grpc:
     enabled: true
+    ingressClassName: nginx
     annotations:
-      kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
       nginx.ingress.kubernetes.io/backend-protocol: GRPC
       cert-manager.io/cluster-issuer: letsencrypt-prod

--- a/charts/dgraph/example_values/ingress/ingress-nginx.yaml
+++ b/charts/dgraph/example_values/ingress/ingress-nginx.yaml
@@ -9,8 +9,8 @@
 global:
   ingress:
     enabled: true
+    ingressClassName: nginx
     annotations:
-      kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
       cert-manager.io/cluster-issuer: letsencrypt-staging
     tls:

--- a/charts/dgraph/templates/alpha/ingress.yaml
+++ b/charts/dgraph/templates/alpha/ingress.yaml
@@ -14,6 +14,9 @@ metadata:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
   {{- end }}
 spec:
+{{- if .Values.alpha.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.alpha.ingress.ingressClassName }}
+{{- end }}
 {{- if .Values.alpha.ingress.tls }}
   tls:
   {{- range .Values.alpha.ingress.tls }}
@@ -61,6 +64,9 @@ metadata:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
   {{- end }}
 spec:
+{{- if .Values.alpha.ingress_grpc.ingressClassName }}
+  ingressClassName: {{ .Values.alpha.ingress_grpc.ingressClassName }}
+{{- end }}
 {{- if .Values.alpha.ingress_grpc.tls }}
   tls:
   {{- range .Values.alpha.ingress_grpc.tls }}

--- a/charts/dgraph/templates/global-ingress.yaml
+++ b/charts/dgraph/templates/global-ingress.yaml
@@ -14,6 +14,9 @@ metadata:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
   {{- end }}
 spec:
+{{- if .Values.global.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.global.ingress.ingressClassName }}
+{{- end }}
 {{- if .Values.global.ingress.tls }}
   tls:
   {{- range .Values.global.ingress.tls }}
@@ -81,6 +84,9 @@ metadata:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
   {{- end }}
 spec:
+{{- if .Values.global.ingress_grpc.ingressClassName }}
+  ingressClassName: {{ .Values.global.ingress_grpc.ingressClassName }}
+{{- end }}
 {{- if .Values.global.ingress_grpc.tls }}
   tls:
   {{- range .Values.global.ingress_grpc.tls }}

--- a/charts/dgraph/templates/ratel/ingress.yaml
+++ b/charts/dgraph/templates/ratel/ingress.yaml
@@ -14,6 +14,9 @@ metadata:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
   {{- end }}
 spec:
+{- if .Values.ratel.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ratel.ingress.ingressClassName }}
+{{- end }}
 {{- if .Values.ratel.ingress.tls }}
   tls:
   {{- range .Values.ratel.ingress.tls }}

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -10,7 +10,7 @@
 image: &image
   registry: docker.io
   repository: dgraph/dgraph
-  tag: v21.03.1
+  tag: v21.12.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -297,6 +297,7 @@ alpha:
   ## This requires an ingress controller to be installed into your k8s cluster
   ingress:
     enabled: false
+    # ingressClassName: nginx
     # hostname: ""
     # annotations: {}
     # tls: {}
@@ -305,6 +306,7 @@ alpha:
   ## This requires an ingress controller to be installed into your k8s cluster
   ingress_grpc:
     enabled: false
+    # ingressClassName: nginx
     # hostname: ""
     # annotations: {}
     # tls: {}    
@@ -491,6 +493,7 @@ ratel:
   ## This requires an ingress controller to be installed into your k8s cluster
   ingress:
     enabled: false
+    # ingressClassName: nginx
     # hostname: ""
     # annotations: {}
     # tls: {}
@@ -634,12 +637,14 @@ global:
   ## This requires an ingress controller to be installed into your k8s cluster
   ingress:
     enabled: false
+    ingressClassName: nginx
     annotations: {}
     tls: {}
     ratel_hostname: ""
     alpha_hostname: ""
   ingress_grpc:
     enabled: false
+    ingressClassName: nginx
     annotations: {}
     tls: {}
     alpha_grpc_hostname: ""  


### PR DESCRIPTION
Ingress class is now a field instead of an annotation. Helm chart is still backwards compatible with older version by just leaving out `ingressClassName`, and leaving in the annotation.

Also, could you please release a new version of the charts? Because the currently published version is pretty old (dgraph v21.03.1)... We could really use this fixed version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/73)
<!-- Reviewable:end -->
