### PR TITLE
chore: Fix typo.

### DIFF
--- a/charts/dgraph/templates/ratel/ingress.yaml
+++ b/charts/dgraph/templates/ratel/ingress.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
   {{- end }}
 spec:
-{- if .Values.ratel.ingress.ingressClassName }}
+{{- if .Values.ratel.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ratel.ingress.ingressClassName }}
 {{- end }}
 {{- if .Values.ratel.ingress.tls }}


### PR DESCRIPTION
Fix template typo with Ratel ingress introduced in #73.

    $ helm lint charts/dgraph
    ==> Linting charts/dgraph
    [ERROR] templates/: parse error at (dgraph/templates/ratel/ingress.yaml:49): unexpected {{end}}

    Error: 1 chart(s) linted, 1 chart(s) failed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/74)
<!-- Reviewable:end -->
