### PR TITLE
Add extra pod labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .cr-release-packages/
 .DS_Store
+.idea

--- a/charts/dgraph/Chart.yaml
+++ b/charts/dgraph/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dgraph
-version: 0.0.19
+version: 0.0.20
 appVersion: v21.12.0
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -68,6 +68,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `zero.name`                              | Zero component name                                                   | `zero`                                              |
 | `zero.metrics.enabled`                   | Add annotations for Prometheus metric scraping                        | `true`                                              |
 | `zero.extraAnnotations`                  | Specify annotations for template metadata                             | `{}`                                                |
+| `zero.podLabels`                         | Specify additional labels for template metadata                       | `{}`                                                |
 | `zero.updateStrategy`                    | Strategy for upgrading zero nodes                                     | `RollingUpdate`                                     |
 | `zero.schedulerName`                     | Configure an explicit scheduler                                       | `nil`                                               |
 | `zero.monitorLabel`                      | Monitor label for zero, used by prometheus.                           | `zero-dgraph-io`                                    |
@@ -107,6 +108,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `alpha.name`                             | Alpha component name                                                  | `alpha`                                             |
 | `alpha.metrics.enabled`                  | Add annotations for Prometheus metric scraping                        | `true`                                              |
 | `alpha.extraAnnotations`                 | Specify annotations for template metadata                             | `{}`                                                |
+| `alpha.podLabels`                        | Specify additional labels for template metadata                       | `{}`                                                |
 | `alpha.monitorLabel`                     | Monitor label for alpha, used by prometheus.                          | `alpha-dgraph-io`                                   |
 | `alpha.updateStrategy`                   | Strategy for upgrading alpha nodes                                    | `RollingUpdate`                                     |
 | `alpha.schedulerName`                    | Configure an explicit scheduler                                       | `nil`                                               |
@@ -165,6 +167,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `ratel.name`                             | Ratel component name                                                  | `ratel`                                             |
 | `ratel.enabled`                          | Ratel service enabled or disabled                                     | `false`                                             |
 | `ratel.extraAnnotations`                 | Specify annotations for template metadata                             | `{}`                                                |
+| `ratel.podLabels`                        | Specify additional labels for template metadata                       | `{}`                                                |
 | `ratel.image.registry`                   | Container registry name                                               | `docker.io`                                         |
 | `ratel.image.repository`                 | Container image name                                                  | `dgraph/ratel`                                      |
 | `ratel.image.tag`                        | Container image tag                                                   | `v21.03.1`                                          |
@@ -190,6 +193,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `ratel.customLivenessProbe`              | Ratel custom liveness probes (if `ratel.livenessProbe` not enabled)   | `{}`                                                |
 | `ratel.customReadinessProbe`             | Ratel custom readiness probes (if `ratel.readinessProbe` not enabled) | `{}`                                                |
 | `backups.name`                           | Backups component name                                                | `backups`                                           |
+| `backups.podLabels`                      | Specify additional labels for template metadata                       | `{}`                                                |
 | `backups.schedulerName`                  | Configure an explicit scheduler for Backups Kubernetes CronJobs       | `nil`                                               |
 | `backups.admin.user`                     | Login user for backups (required if ACL enabled)                      | `groot`                                             |
 | `backups.admin.password`                 | Login user password for backups (required if ACL enabled)             | `password`                                          |

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -73,6 +73,9 @@ spec:
         chart: {{ template "dgraph.chart" . }}
         release: {{ .Release.Name }}
         component: {{ .Values.alpha.name }}
+        {{- if .Values.alpha.podLabels }}
+{{- .Values.alpha.podLabels | toYaml | indent 8}}
+        {{- end }}
     spec:
       {{- if .Values.alpha.schedulerName }}
       schedulerName: {{ .Values.alpha.schedulerName }}

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -74,7 +74,7 @@ spec:
         release: {{ .Release.Name }}
         component: {{ .Values.alpha.name }}
         {{- if .Values.alpha.podLabels }}
-{{- .Values.alpha.podLabels | toYaml | indent 8}}
+{{ .Values.alpha.podLabels | toYaml | indent 8}}
         {{- end }}
     spec:
       {{- if .Values.alpha.schedulerName }}

--- a/charts/dgraph/templates/backups/cronjob-full.yaml
+++ b/charts/dgraph/templates/backups/cronjob-full.yaml
@@ -34,7 +34,7 @@ spec:
           labels:
             cronjob: {{ template "dgraph.backups.fullname" . }}-full
             {{- if .Values.backups.podLabels }}
-{{- .Values.backups.podLabels | toYaml | indent 12}}
+{{ .Values.backups.podLabels | toYaml | indent 12}}
             {{- end }}
         spec:
           {{- if .Values.backups.schedulerName }}

--- a/charts/dgraph/templates/backups/cronjob-full.yaml
+++ b/charts/dgraph/templates/backups/cronjob-full.yaml
@@ -33,6 +33,9 @@ spec:
         metadata:
           labels:
             cronjob: {{ template "dgraph.backups.fullname" . }}-full
+            {{- if .Values.backups.podLabels }}
+{{- .Values.backups.podLabels | toYaml | indent 12}}
+            {{- end }}
         spec:
           {{- if .Values.backups.schedulerName }}
           schedulerName: {{ .Values.backups.schedulerName }}

--- a/charts/dgraph/templates/backups/cronjob-inc.yaml
+++ b/charts/dgraph/templates/backups/cronjob-inc.yaml
@@ -33,6 +33,9 @@ spec:
         metadata:
           labels:
             cronjob: {{ template "dgraph.backups.fullname" . }}-inc
+            {{- if .Values.backups.podLabels }}
+{{- .Values.backups.podLabels | toYaml | indent 12}}
+            {{- end }}
         spec:
           {{- if .Values.backups.schedulerName }}
           schedulerName: {{ .Values.backups.schedulerName }}

--- a/charts/dgraph/templates/backups/cronjob-inc.yaml
+++ b/charts/dgraph/templates/backups/cronjob-inc.yaml
@@ -34,7 +34,7 @@ spec:
           labels:
             cronjob: {{ template "dgraph.backups.fullname" . }}-inc
             {{- if .Values.backups.podLabels }}
-{{- .Values.backups.podLabels | toYaml | indent 12}}
+{{ .Values.backups.podLabels | toYaml | indent 12}}
             {{- end }}
         spec:
           {{- if .Values.backups.schedulerName }}

--- a/charts/dgraph/templates/ratel/deployment.yaml
+++ b/charts/dgraph/templates/ratel/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         component: {{ .Values.ratel.name }}
         release: {{ .Release.Name }}
         {{- if .Values.ratel.podLabels }}
-{{- .Values.ratel.podLabels | toYaml | indent 8}}
+{{ .Values.ratel.podLabels | toYaml | indent 8}}
         {{- end }}
     spec:
       {{- if .Values.ratel.schedulerName }}

--- a/charts/dgraph/templates/ratel/deployment.yaml
+++ b/charts/dgraph/templates/ratel/deployment.yaml
@@ -30,6 +30,9 @@ spec:
         chart: {{ template "dgraph.chart" . }}
         component: {{ .Values.ratel.name }}
         release: {{ .Release.Name }}
+        {{- if .Values.ratel.podLabels }}
+{{- .Values.ratel.podLabels | toYaml | indent 8}}
+        {{- end }}
     spec:
       {{- if .Values.ratel.schedulerName }}
       schedulerName: {{ .Values.ratel.schedulerName }}

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -29,9 +29,6 @@ metadata:
     component: {{ .Values.zero.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    {{- if .Values.zero.podLabels }}
-{{- .Values.zero.podLabels | toYaml | indent 8}}
-    {{- end }}
 spec:
   serviceName: {{ template "dgraph.zero.fullname" . }}-headless
   replicas: {{ .Values.zero.replicaCount }}
@@ -69,6 +66,9 @@ spec:
         chart: {{ template "dgraph.chart" . }}
         release: {{ .Release.Name }}
         component: {{ .Values.zero.name }}
+        {{- if .Values.zero.podLabels }}
+{{ .Values.zero.podLabels | toYaml | indent 8}}
+        {{- end }}
     spec:
       {{- if .Values.zero.schedulerName }}
       schedulerName: {{ .Values.zero.schedulerName }}

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -29,6 +29,9 @@ metadata:
     component: {{ .Values.zero.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.zero.podLabels }}
+{{- .Values.zero.podLabels | toYaml | indent 8}}
+    {{- end }}
 spec:
   serviceName: {{ template "dgraph.zero.fullname" . }}-headless
   replicas: {{ .Values.zero.replicaCount }}

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -36,6 +36,9 @@ zero:
   ## StatefulSet spec.template.metadata.annotations
   extraAnnotations: {}
 
+  ## StatefulSet spec.template.metadata.labels
+  podLabels: {}
+
   monitorLabel: zero-dgraph-io
   ## StatefulSet controller supports automated updates. There are two valid update strategies: RollingUpdate and OnDelete
   ## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets
@@ -208,6 +211,9 @@ alpha:
 
   ## StatefulSet spec.template.metadata.annotations
   extraAnnotations: {}
+
+  ## StatefulSet spec.template.metadata.labels
+  podLabels: {}
 
   monitorLabel: alpha-dgraph-io
   ## StatefulSet controller supports automated updates. There are two valid update strategies: RollingUpdate and OnDelete
@@ -443,6 +449,9 @@ ratel:
   ## Deployment spec.template.metadata.annotations
   extraAnnotations: {}
 
+  ## Deployment spec.template.metadata.labels
+  podLabels: {}
+
   ## NOTE: Ratel is no longer included in dgraph image since dgraph/dgraph:v21.03.0
   ##       The Ratel image is dgraph/ratel.
   image:
@@ -548,6 +557,8 @@ backups:
   ## https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
   ##
   # schedulerName: stork
+  ## CronJob spec.jobTemplate.spec.template.metadata.labels
+  podLabels: {}
   admin:
     ## backup user and password that is a member of 'guardians'group used to
     ## login if ACLs are enabled.  This fetches an access token used to trigger backups


### PR DESCRIPTION
The motivation for this PR was running dgraph on k8s cluster with Istio. The sidecar injection can be controlled by labeling the namespace or the pods. In this case:
- if the sidecar injection is enabled on namespace level - backup will never end since the pod will never finish (sidecar will run forever) and no option to disable it for backup pods
- no option to enable it for alpha/zero pods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/75)
<!-- Reviewable:end -->
