### PR TITLE
chore(other): Fix env variable name for lambda URL

### DIFF
--- a/charts/dgraph-lambda/README.md
+++ b/charts/dgraph-lambda/README.md
@@ -42,11 +42,11 @@ Dgraph Alpha needs to be configured with the `--graphql lambda-url=<url>` argume
 ```bash
 helm install $DGRAPH_REL dgraph/dgraph \
   --namespace $NS \
-  --set alpha.extraEnvs[0].name=DGRAPH_ALPHA_GRAPHQL \
-  --set alpha.extraEnvs[0].value=lambda-url=http://$LAMBDA_REL-dgraph-lambda.$NS.svc:80/graphql-worker
+  --set alpha.extraEnvs[0].name=DGRAPH_ALPHA_LAMBDA \
+  --set alpha.extraEnvs[0].value=url=http://$LAMBDA_REL-dgraph-lambda.$NS.svc:80/graphql-worker
 ```
 
-The `DGRAPH_ALPHA_GRAPHQL_LAMBDA_URL` environment variable points to Dgraph Lambda service that will be deployed in the next step.  The format Dgraph Lambda domain name is formatted as follows:
+The `DGRAPH_ALPHA_LAMBDA_URL` environment variable points to Dgraph Lambda service that will be deployed in the next step.  The format Dgraph Lambda domain name is formatted as follows:
 
 ```
 http://<helm-chart-release-name>-dgraph-lambda.<namesapce>.svc/graphql-worker

--- a/helmfiles/lambda/README.md
+++ b/helmfiles/lambda/README.md
@@ -88,8 +88,8 @@ If you would like to forgo using `helmfile` and instead just use the vanilla `he
 
 ```bash
 helm install dev ../../charts/dgraph \
-  --set alpha.extraEnvs[0].name=DGRAPH_ALPHA_GRAPHQL_LAMBDA_URL \
-  --set alpha.extraEnvs[0].value=http://lambda-dgraph-lambda.default.svc/graphql-worker
+  --set alpha.extraEnvs[0].name=DGRAPH_ALPHA_LAMBDA \
+  --set alpha.extraEnvs[0].value=url=http://lambda-dgraph-lambda.default.svc/graphql-worker
 
 helm install lambda ../../charts/dgraph-lambda \
   --values example/script.yaml \

--- a/helmfiles/lambda/helmfile.yaml
+++ b/helmfiles/lambda/helmfile.yaml
@@ -11,8 +11,8 @@ releases:
             ##  - http://<helm-chart-release-name>-dgraph-lambda.<namespace>.svc/graphql-worker
             ## NOTE: Configuration env vars have changed in v21.03.
             ## Use appropriate value for the dgraph version used.
-            - name: DGRAPH_ALPHA_GRAPHQL
-              value: lambda-url=http://lambda-dgraph-lambda.default.svc/graphql-worker
+            - name: DGRAPH_ALPHA_LAMBDA
+              value: url=http://lambda-dgraph-lambda.default.svc/graphql-worker
   - name: lambda
     namespace: default
     chart: {{ env "PWD" }}/../../charts/dgraph-lambda


### PR DESCRIPTION
**Description**

Current snippets have incorrect env variable. As a result, the lambda server URL is ignored. The new syntax was introduced in: https://github.com/dgraph-io/dgraph/commit/12c3ef564cde11ecc3de96ec1516b3148e52d795

This PR fixes this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/76)
<!-- Reviewable:end -->
