### PR TITLE
updated ingress examples and default value

### DIFF
--- a/charts/dgraph/example_values/ingress/ingress-gce.yaml
+++ b/charts/dgraph/example_values/ingress/ingress-gce.yaml
@@ -1,5 +1,6 @@
-# GKE Default Ingress
+# GKE Default Ingress (external L7 load balancer)
 # * https://cloud.google.com/kubernetes-engine/docs/concepts/ingress
+# * https://github.com/kubernetes/ingress-gce
 alpha:
   ingress:
     enabled: true

--- a/charts/dgraph/example_values/ingress/ingress-nginx-grpc.yaml
+++ b/charts/dgraph/example_values/ingress/ingress-nginx-grpc.yaml
@@ -3,7 +3,7 @@
 # Two ingress resources will configured for mixed GPRC and HTTP support.
 #
 # TLS will be terminated by the ingress controller.  The ingress controller
-# should be configured as an Layer 4 external load balancer.
+# should be configured as a Layer 4 external load balancer.
 #
 # References:
 # * https://github.com/kubernetes-sigs/external-dns/

--- a/charts/dgraph/example_values/ingress/ingress-nginx.yaml
+++ b/charts/dgraph/example_values/ingress/ingress-nginx.yaml
@@ -1,7 +1,7 @@
 # ingress-nginx with certificate manager
 # --------------------------------------
 # TLS will be terminated by the ingress controller.  The ingress controller
-# should be configured an Layer 4 external load balancer.
+# should be configured as an Layer 4 external load balancer.
 # References:
 # * https://github.com/kubernetes-sigs/external-dns/
 # * https://cert-manager.io/

--- a/charts/dgraph/example_values/ingress/ingress-nginx.yaml
+++ b/charts/dgraph/example_values/ingress/ingress-nginx.yaml
@@ -1,7 +1,7 @@
 # ingress-nginx with certificate manager
 # --------------------------------------
 # TLS will be terminated by the ingress controller.  The ingress controller
-# should be configured as an Layer 4 external load balancer.
+# should be configured as a Layer 4 external load balancer.
 # References:
 # * https://github.com/kubernetes-sigs/external-dns/
 # * https://cert-manager.io/

--- a/charts/dgraph/example_values/ingress/kubernetes-ingress.yaml
+++ b/charts/dgraph/example_values/ingress/kubernetes-ingress.yaml
@@ -3,7 +3,7 @@
 # Two ingress resources will configured for mixed GPRC and HTTP support.
 #
 # TLS will be terminated by the ingress controller.  The ingress controller
-# should be configured as an Layer 4 external load balancer.
+# should be configured as a Layer 4 external load balancer.
 #
 # References:
 # * https://github.com/nginxinc/kubernetes-ingress

--- a/charts/dgraph/example_values/ingress/kubernetes-ingress.yaml
+++ b/charts/dgraph/example_values/ingress/kubernetes-ingress.yaml
@@ -1,4 +1,4 @@
-# ingress-nginx with GRPC support
+# kubernetes-ingress (NGINX ingress) with GRPC support
 # --------------------------------------
 # Two ingress resources will configured for mixed GPRC and HTTP support.
 #
@@ -6,18 +6,16 @@
 # should be configured as an Layer 4 external load balancer.
 #
 # References:
-# * https://github.com/kubernetes-sigs/external-dns/
+# * https://github.com/nginxinc/kubernetes-ingress
+# * https://docs.nginx.com/nginx-ingress-controller/configuration/global-configuration/configmap-resource/#listeners
+# * https://github.com/nginxinc/kubernetes-ingress/tree/v2.3.0/examples/grpc-services
 # * https://cert-manager.io/
-# * https://kubernetes.github.io/ingress-nginx/
-# * https://kubernetes.github.io/ingress-nginx/examples/grpc/
-# * https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/grpc
+
 global:
   ingress:
     enabled: true
     ingressClassName: nginx
     annotations:
-      nginx.ingress.kubernetes.io/ssl-redirect: "true"
-      nginx.ingress.kubernetes.io/backend-protocol: HTTP
       cert-manager.io/cluster-issuer: letsencrypt-prod
     tls:
       - hosts:
@@ -30,8 +28,9 @@ global:
     enabled: true
     ingressClassName: nginx
     annotations:
-      nginx.ingress.kubernetes.io/ssl-redirect: "true"
-      nginx.ingress.kubernetes.io/backend-protocol: GRPC
+      # NOTE: http2 must be configured in configmap for NGINX ingress controller.
+      # IMPORTANT: Change <RELEASE> to release name used at install, e.g. my-release
+      nginx.org/grpc-services: "<RELEASE>-dgraph-alpha"
       cert-manager.io/cluster-issuer: letsencrypt-prod
     tls:
       - hosts:

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -96,7 +96,8 @@ zero:
   ## For minikube, set this to NodePort, elsewhere use LoadBalancer
   ##
   service:
-    type: ClusterIP
+    type: ClusterIP    # All hostnames must be listed for grpc + https ingress shared cert secret
+
     annotations: {}
     ## StatefulSet pods will need to have addresses published in order to
     ## communicate to each other in order to enter a ready state.
@@ -637,14 +638,14 @@ global:
   ## This requires an ingress controller to be installed into your k8s cluster
   ingress:
     enabled: false
-    ingressClassName: nginx
+    ingressClassName: null
     annotations: {}
     tls: {}
     ratel_hostname: ""
     alpha_hostname: ""
   ingress_grpc:
     enabled: false
-    ingressClassName: nginx
+    ingressClassName: null
     annotations: {}
     tls: {}
     alpha_grpc_hostname: ""  


### PR DESCRIPTION
The example for ingress-nginx for mixed grpc + https was technically functional, but not correct.  

* updated so that only proper certificates are generated via cert-manager.   
* added kubernetes-ingress for NGINX Ingress Controller example
* updated default value of  `ingressClassName` to  `null`
* minor comment corrections

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/77)
<!-- Reviewable:end -->
