### PR TITLE
[dgraph] add support for service accounts

### DIFF
--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -65,6 +65,9 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `image.pullPolicy`                       | Container pull policy                                                 | `IfNotPresent`                                      |
 | `nameOverride`                           | Deployment name override (will append the release name)               | `nil`                                               |
 | `fullnameOverride`                       | Deployment full name override (the release name is ignored)           | `nil`                                               |
+| `serviceAccount.create`                  | Create ServiceAccount                                                 | `true`                                              |
+| `serviceAccount.annotations`             | ServiceAccount annotations                                            | `{}`                                                |
+| `serviceAccount.name`                    | ServiceAccount name                                                   | `dgraph`                                            |
 | `zero.name`                              | Zero component name                                                   | `zero`                                              |
 | `zero.metrics.enabled`                   | Add annotations for Prometheus metric scraping                        | `true`                                              |
 | `zero.extraAnnotations`                  | Specify annotations for template metadata                             | `{}`                                                |

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -75,7 +75,7 @@ spec:
         component: {{ .Values.alpha.name }}
     spec:
       {{- if .Values.serviceAccount.create }}
-      serviceAccountName: {{ .Values.servcieAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- end }}
       {{- if .Values.alpha.schedulerName }}
       schedulerName: {{ .Values.alpha.schedulerName }}

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -74,6 +74,9 @@ spec:
         release: {{ .Release.Name }}
         component: {{ .Values.alpha.name }}
     spec:
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.servcieAccount.name }}
+      {{- end }}
       {{- if .Values.alpha.schedulerName }}
       schedulerName: {{ .Values.alpha.schedulerName }}
       {{- end }}

--- a/charts/dgraph/templates/backups/cronjob-full.yaml
+++ b/charts/dgraph/templates/backups/cronjob-full.yaml
@@ -35,7 +35,7 @@ spec:
             cronjob: {{ template "dgraph.backups.fullname" . }}-full
         spec:
           {{- if .Values.serviceAccount.create }}
-          serviceAccountName: {{ .Values.servcieAccount.name }}
+          serviceAccountName: {{ .Values.serviceAccount.name }}
           {{- end }}
           {{- if .Values.backups.schedulerName }}
           schedulerName: {{ .Values.backups.schedulerName }}

--- a/charts/dgraph/templates/backups/cronjob-full.yaml
+++ b/charts/dgraph/templates/backups/cronjob-full.yaml
@@ -34,6 +34,9 @@ spec:
           labels:
             cronjob: {{ template "dgraph.backups.fullname" . }}-full
         spec:
+          {{- if .Values.serviceAccount.create }}
+          serviceAccountName: {{ .Values.servcieAccount.name }}
+          {{- end }}
           {{- if .Values.backups.schedulerName }}
           schedulerName: {{ .Values.backups.schedulerName }}
           {{- end }}

--- a/charts/dgraph/templates/backups/cronjob-inc.yaml
+++ b/charts/dgraph/templates/backups/cronjob-inc.yaml
@@ -34,6 +34,9 @@ spec:
           labels:
             cronjob: {{ template "dgraph.backups.fullname" . }}-inc
         spec:
+          {{- if .Values.serviceAccount.create }}
+          serviceAccountName: {{ .Values.servcieAccount.name }}
+          {{- end }}
           {{- if .Values.backups.schedulerName }}
           schedulerName: {{ .Values.backups.schedulerName }}
           {{- end }}

--- a/charts/dgraph/templates/backups/cronjob-inc.yaml
+++ b/charts/dgraph/templates/backups/cronjob-inc.yaml
@@ -35,7 +35,7 @@ spec:
             cronjob: {{ template "dgraph.backups.fullname" . }}-inc
         spec:
           {{- if .Values.serviceAccount.create }}
-          serviceAccountName: {{ .Values.servcieAccount.name }}
+          serviceAccountName: {{ .Values.serviceAccount.name }}
           {{- end }}
           {{- if .Values.backups.schedulerName }}
           schedulerName: {{ .Values.backups.schedulerName }}

--- a/charts/dgraph/templates/ratel/deployment.yaml
+++ b/charts/dgraph/templates/ratel/deployment.yaml
@@ -31,6 +31,9 @@ spec:
         component: {{ .Values.ratel.name }}
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.servcieAccount.name }}
+      {{- end }}
       {{- if .Values.ratel.schedulerName }}
       schedulerName: {{ .Values.ratel.schedulerName }}
       {{- end }}

--- a/charts/dgraph/templates/ratel/deployment.yaml
+++ b/charts/dgraph/templates/ratel/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         release: {{ .Release.Name }}
     spec:
       {{- if .Values.serviceAccount.create }}
-      serviceAccountName: {{ .Values.servcieAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- end }}
       {{- if .Values.ratel.schedulerName }}
       schedulerName: {{ .Values.ratel.schedulerName }}

--- a/charts/dgraph/templates/serviceaccount.yaml
+++ b/charts/dgraph/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.servcieAccount.name }}
+  name: {{ .Values.serviceAccount.name }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/serviceaccount.yaml
+++ b/charts/dgraph/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.servcieAccount.name }}
+  labels:
+    app: {{ template "dgraph.name" . }}
+    chart: {{ template "dgraph.chart" . }}
+    component: {{ .Values.alpha.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -68,7 +68,7 @@ spec:
         component: {{ .Values.zero.name }}
     spec:
       {{- if .Values.serviceAccount.create }}
-      serviceAccountName: {{ .Values.servcieAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- end }}
       {{- if .Values.zero.schedulerName }}
       schedulerName: {{ .Values.zero.schedulerName }}

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -67,6 +67,9 @@ spec:
         release: {{ .Release.Name }}
         component: {{ .Values.zero.name }}
     spec:
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.servcieAccount.name }}
+      {{- end }}
       {{- if .Values.zero.schedulerName }}
       schedulerName: {{ .Values.zero.schedulerName }}
       {{- end }}

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -28,6 +28,15 @@ image: &image
   ##
   debug: false
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: dgraph
+
 zero:
   name: zero
   metrics:


### PR DESCRIPTION
**problem**: Dgraph needs to run pods under the context of a service account, so that they can use security features.  For example:
     * Access to cloud resources: [GKE Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity), [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html), [Azure AD Workload Identity](https://azure.github.io/azure-workload-identity/docs/), [Azure AD Pod Identity](https://github.com/Azure/aad-pod-identity)
     * [SMI Traffic Access](https://github.com/servicemeshinterface/smi-spec/blob/main/apis/traffic-access/v1alpha2/traffic-access.md) control to restrict flow of traffic in a service mesh

**solution**: Add support for service accounts

**testing**:

**HOW TO TEST** You need to have a K8S running somewhere, mini-kube is fine, and you do not need to deploy anything.  You can run the commands below to test the branch logic, and the expected result is that a service account will be added, zero and alpha sts will have a service account for pod spec, and also ratel deployment (if enabled) will have a service account for the pod spec.  If create=false, then these should not be added. If there's any other test that should be run, please mention them in the discussion.

```bash
# TEST 1: test defaults 
helm template ./charts/dgraph/ | bat -l yaml
# TEST 2: test with turned off
helm template ./charts/dgraph/ --set serviceAccount.create=false | bat -l yaml
# TEST 3
helm template ./charts/dgraph/ --set serviceAccount.name=fido | bat -l yaml
```


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/79)
<!-- Reviewable:end -->
