### PR TITLE
override default ratel args

### DIFF
--- a/charts/dgraph/templates/ratel/deployment.yaml
+++ b/charts/dgraph/templates/ratel/deployment.yaml
@@ -56,6 +56,7 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- end }}
+        args: {{ .Values.ratel.args | toYaml | nindent 10 }}
         command:
           - dgraph-ratel
         ports:

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -486,6 +486,9 @@ ratel:
   # Extra environment variables which will be appended to the env: definition for the container.
   extraEnvs: []
 
+  # Arguments appended to a command dgraph-ratel command
+  args: []
+
   ## Kubernetes configuration
   ## For minikube, set this to NodePort, elsewhere use ClusterIP or LoadBalancer
   ##


### PR DESCRIPTION
Need an ability to override default ratel args. Unfortunately ratel doesn't grab these args from env variables, so helm `ratel.extraEnvs` variable is useless.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/81)
<!-- Reviewable:end -->
