### PR TITLE
update version and document Ratel arg feature

### DIFF
--- a/charts/dgraph/Chart.yaml
+++ b/charts/dgraph/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: dgraph
 version: 0.0.20
-appVersion: v21.12.0
+appVersion: v22.0.2
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:
 - dgraph

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -61,7 +61,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | ---------------------------------------- | --------------------------------------------------------------------- | --------------------------------------------------- |
 | `image.registry`                         | Container registry name                                               | `docker.io`                                         |
 | `image.repository`                       | Container image name                                                  | `dgraph/dgraph`                                     |
-| `image.tag`                              | Container image tag                                                   | `v21.03.1`                                          |
+| `image.tag`                              | Container image tag                                                   | `v22.0.2`                                           |
 | `image.pullPolicy`                       | Container pull policy                                                 | `IfNotPresent`                                      |
 | `nameOverride`                           | Deployment name override (will append the release name)               | `nil`                                               |
 | `fullnameOverride`                       | Deployment full name override (the release name is ignored)           | `nil`                                               |
@@ -182,6 +182,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `ratel.schedulerName`                    | Configure an explicit scheduler                                       | `nil`                                               |
 | `ratel.replicaCount`                     | Number of ratel nodes                                                 | `1`                                                 |
 | `ratel.extraEnvs`                        | Extra env vars                                                        | `[]`                                                |
+| `ratel.args`                             | Ratel command line arguments                                          | `[]`                                                |
 | `ratel.service.type`                     | Ratel service type                                                    | `ClusterIP`                                         |
 | `ratel.service.labels`                   | Ratel Service labels                                                  | `{}`                                                |
 | `ratel.service.annotations`              | Ratel Service annotations                                             | `{}`                                                |

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -10,7 +10,7 @@
 image: &image
   registry: docker.io
   repository: dgraph/dgraph
-  tag: v21.12.0
+  tag: v22.0.2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
This updates Dgraph version to `v22.0.2` and documents Ratel args override feature.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/83)
<!-- Reviewable:end -->
