### PR TITLE
roll statefulsets on configmap updates

### DIFF
--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -59,6 +59,9 @@ spec:
       name: {{ template "dgraph.alpha.fullname" . }}
       {{- if or .Values.alpha.metrics.enabled .Values.alpha.extraAnnotations }}
       annotations:
+        {{- if .Values.alpha.configFile }}
+        checksum/config: {{ include (print $.Template.BasePath "/alpha/configs.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.alpha.metrics.enabled }}
         prometheus.io/path: /debug/prometheus_metrics
         prometheus.io/port: "8080"

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -52,6 +52,9 @@ spec:
       name: {{ template "dgraph.zero.fullname" . }}
       {{- if or .Values.zero.metrics.enabled .Values.zero.extraAnnotations }}
       annotations:
+        {{- if .Values.zero.configFile }}
+        checksum/config: {{ include (print $.Template.BasePath "/zero/configs.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.zero.metrics.enabled }}
         prometheus.io/path: /debug/prometheus_metrics
         prometheus.io/port: "6080"


### PR DESCRIPTION
This adds annotations for pod spec in statefulset for automatic rollout on config map updates per helm [tip](https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments).


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/85)
<!-- Reviewable:end -->
