### PR TITLE
add servicemonitors

### DIFF
--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -70,6 +70,12 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `serviceAccount.name`                    | ServiceAccount name                                                   | `dgraph`                                            |
 | `zero.name`                              | Zero component name                                                   | `zero`                                              |
 | `zero.metrics.enabled`                   | Add annotations for Prometheus metric scraping                        | `true`                                              |
+| `zero.servicemonitor.enabled`            | Enable Prometheus Operator ServiceMonitor monitoring for zero nodes   | `false`                                             |
+| `zero.servicemonitor.annotations`        | Add custom annotations to ServiceMonitor for zero nodes               | `{}`                                                |
+| `zero.servicemonitor.interval`           | Prometheus scrape interval	for zero nodes metrics                     | `60s`                                               |
+| `zero.servicemonitor.labels`             | Add custom labels to ServiceMonitor for zero nodes                    | `{}`                                                |
+| `zero.servicemonitor.namespace`          | Whether to limit ServiceMonitor to the release namespace or not       | `nil`                                               |
+| `zero.servicemonitor.scrapeTimeout`      | Prometheus scrape timeout for zero nodes metrics	                     | `10s`                                               |
 | `zero.extraAnnotations`                  | Specify annotations for template metadata                             | `{}`                                                |
 | `zero.podLabels`                         | Specify additional labels for template metadata                       | `{}`                                                |
 | `zero.updateStrategy`                    | Strategy for upgrading zero nodes                                     | `RollingUpdate`                                     |
@@ -112,6 +118,12 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `zero.customReadinessProbe`              | Zero custom readiness probes  (if `zero.readinessProbe` not enabled)  | `{}`                                                |
 | `alpha.name`                             | Alpha component name                                                  | `alpha`                                             |
 | `alpha.metrics.enabled`                  | Add annotations for Prometheus metric scraping                        | `true`                                              |
+| `alpha.servicemonitor.enabled`           | Enable Prometheus Operator ServiceMonitor monitoring for alpha nodes  | `false`                                             |
+| `alpha.servicemonitor.annotations`       | Add custom annotations to ServiceMonitor for alpha nodes              | `{}`                                                |
+| `alpha.servicemonitor.interval`          | Prometheus scrape interval	for alpha nodes metrics                    | `60s`                                               |
+| `alpha.servicemonitor.labels`            | Add custom labels to ServiceMonitor for alpha nodes                   | `{}`                                                |
+| `alpha.servicemonitor.namespace`         | Whether to limit ServiceMonitor to the release namespace or not       | `nil`                                               |
+| `alpha.servicemonitor.scrapeTimeout`     | Prometheus scrape timeout for alpha nodes metrics	                   | `10s`                                               |
 | `alpha.extraAnnotations`                 | Specify annotations for template metadata                             | `{}`                                                |
 | `alpha.podLabels`                        | Specify additional labels for template metadata                       | `{}`                                                |
 | `alpha.monitorLabel`                     | Monitor label for alpha, used by prometheus.                          | `alpha-dgraph-io`                                   |

--- a/charts/dgraph/templates/alpha/servicemonitor.yaml
+++ b/charts/dgraph/templates/alpha/servicemonitor.yaml
@@ -1,0 +1,40 @@
+{{- if and (not .Values.alpha.metrics.enabled) .Values.alpha.servicemonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "dgraph.alpha.fullname" . }}
+  labels:
+    app: {{ template "dgraph.name" . }}
+    chart: {{ template "dgraph.chart" . }}
+    component: {{ .Values.alpha.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- with .Values.alpha.servicemonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- if .Values.alpha.servicemonitor.annotations }}
+  annotations:
+    {{- with .Values.alpha.servicemonitor.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}
+spec:
+  jobLabel: {{ template "dgraph.alpha.fullname" . }}
+  selector:
+    matchLabels:
+      app: {{ template "dgraph.name" . }}
+      chart: {{ template "dgraph.chart" . }}
+      component: {{ .Values.alpha.name }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+{{- if .Values.alpha.servicemonitor.namespace }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}
+  endpoints:
+  - path: /debug/prometheus_metrics
+    port: http-alpha
+    interval: {{ .Values.alpha.servicemonitor.interval }}
+    scrapeTimeout: {{ .Values.alpha.servicemonitor.scrapeTimeout }}
+{{- end }}

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
   template:
     metadata:
       name: {{ template "dgraph.alpha.fullname" . }}
-      {{- if or .Values.alpha.metrics.enabled .Values.alpha.extraAnnotations }}
+      {{- if or (and .Values.alpha.metrics.enabled (not .Values.alpha.servicemonitor.enabled)) .Values.alpha.extraAnnotations }}
       annotations:
         {{- if .Values.alpha.metrics.enabled }}
         prometheus.io/path: /debug/prometheus_metrics

--- a/charts/dgraph/templates/zero/servicemonitor.yaml
+++ b/charts/dgraph/templates/zero/servicemonitor.yaml
@@ -1,0 +1,40 @@
+{{- if and (not .Values.zero.metrics.enabled) .Values.zero.servicemonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "dgraph.zero.fullname" . }}
+  labels:
+    app: {{ template "dgraph.name" . }}
+    chart: {{ template "dgraph.chart" . }}
+    component: {{ .Values.zero.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- with .Values.zero.servicemonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- if .Values.zero.servicemonitor.annotations }}
+  annotations:
+    {{- with .Values.zero.servicemonitor.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}
+spec:
+  jobLabel: {{ template "dgraph.zero.fullname" . }}
+  selector:
+    matchLabels:
+      app: {{ template "dgraph.name" . }}
+      chart: {{ template "dgraph.chart" . }}
+      component: {{ .Values.zero.name }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+{{- if .Values.zero.servicemonitor.namespace }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}
+  endpoints:
+  - path: /debug/prometheus_metrics
+    port: http-zero
+    interval: {{ .Values.zero.servicemonitor.interval }}
+    scrapeTimeout: {{ .Values.zero.servicemonitor.scrapeTimeout }}
+{{- end }}

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -50,7 +50,7 @@ spec:
   template:
     metadata:
       name: {{ template "dgraph.zero.fullname" . }}
-      {{- if or .Values.zero.metrics.enabled .Values.zero.extraAnnotations }}
+      {{- if or (and .Values.zero.metrics.enabled (not .Values.zero.servicemonitor.enabled)) .Values.zero.extraAnnotations }}
       annotations:
         {{- if .Values.zero.metrics.enabled }}
         prometheus.io/path: /debug/prometheus_metrics

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -41,6 +41,12 @@ zero:
   name: zero
   metrics:
     enabled: true
+  servicemonitor:
+    enabled: false
+    interval: 60s
+    scrapeTimeout: 10s
+    labels: {}
+    annotations: {}
 
   ## StatefulSet spec.template.metadata.annotations
   extraAnnotations: {}
@@ -221,6 +227,12 @@ alpha:
   name: alpha
   metrics:
     enabled: true
+  servicemonitor:
+    enabled: false
+    interval: 60s
+    scrapeTimeout: 10s
+    labels: {}
+    annotations: {}
 
   ## StatefulSet spec.template.metadata.annotations
   extraAnnotations: {}


### PR DESCRIPTION
Adds ServiceMonitor objects for integration with Prometheus Operator.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/86)
<!-- Reviewable:end -->
