### PR TITLE
publishNotReadyAddresses moved to headless service

### DIFF
--- a/charts/dgraph/Chart.yaml
+++ b/charts/dgraph/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dgraph
-version: 0.0.21
+version: 0.1.0
 appVersion: v22.0.2
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:

--- a/charts/dgraph/Chart.yaml
+++ b/charts/dgraph/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dgraph
-version: 0.0.20
+version: 0.0.21
 appVersion: v22.0.2
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:

--- a/charts/dgraph/templates/alpha/svc-headless.yaml
+++ b/charts/dgraph/templates/alpha/svc-headless.yaml
@@ -15,11 +15,12 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-  - name: grpc-alpha-int
-    port: 7080
-    targetPort: 7080
+    - name: grpc-alpha-int
+      port: 7080
+      targetPort: 7080
   selector:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.alpha.name }}
     release: {{ .Release.Name }}
+  publishNotReadyAddresses: {{ .Values.alpha.service.publishNotReadyAddresses }}

--- a/charts/dgraph/templates/alpha/svc.yaml
+++ b/charts/dgraph/templates/alpha/svc.yaml
@@ -25,16 +25,15 @@ spec:
   externalTrafficPolicy: {{ .Values.alpha.service.externalTrafficPolicy }}
   {{- end }}
   ports:
-  - port: 8080
-    targetPort: 8080
-    name: http-alpha
-  - port: 9080
-    name: grpc-alpha
+    - port: 8080
+      targetPort: 8080
+      name: http-alpha
+    - port: 9080
+      name: grpc-alpha
   {{- with .Values.alpha.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  publishNotReadyAddresses: {{ .Values.alpha.service.publishNotReadyAddresses }}
   selector:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/zero/svc-headless.yaml
+++ b/charts/dgraph/templates/zero/svc-headless.yaml
@@ -15,11 +15,12 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-  - name: grpc-zero
-    port: 5080
-    targetPort: 5080
+    - name: grpc-zero
+      port: 5080
+      targetPort: 5080
   selector:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}
     release: {{ .Release.Name }}
     component: {{ .Values.zero.name }}
+  publishNotReadyAddresses: {{ .Values.zero.service.publishNotReadyAddresses }}

--- a/charts/dgraph/templates/zero/svc.yaml
+++ b/charts/dgraph/templates/zero/svc.yaml
@@ -25,17 +25,16 @@ spec:
   externalTrafficPolicy: {{ .Values.zero.externalTrafficPolicy }}
   {{- end }}
   ports:
-  - port: 5080
-    targetPort: 5080
-    name: grpc-zero
-  - port: 6080
-    targetPort: 6080
-    name: http-zero
+    - port: 5080
+      targetPort: 5080
+      name: grpc-zero
+    - port: 6080
+      targetPort: 6080
+      name: http-zero
   {{- with .Values.zero.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  publishNotReadyAddresses: {{ .Values.zero.service.publishNotReadyAddresses }}
   selector:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}


### PR DESCRIPTION
This is quick fix for bug in helm chart, where `publishNotReadyAddresses` should be for the headless service, not the published service.  This will allow Dgraph Alpha pods to communicate with each other when Readiness check fails, but does not open the service up for traffic.

This change does two small changes:

* move `publishNotReadyAddresses` from service to headless service.
* version bump major version as this changes (fixes) functionality of the `alpha.service.publishNotReadyAddresses` and `zero.service.publishNotReadyAddresses`.

## Background

Currently, Dgraph pods will fail to communicate with each other if the Readiness check on any Dgraph pod fails.  This will put the cluster in a broken state.  Furthermore, this when Dgraph Alpha or Zero is unavailable, traffic can be sent to the pods that are failing.

This small fix allows change this behavior, so that if Readiness checks are failing, outside traffic (through non-headless service) to the Dgraph pods will not happen, but internally (through the headless service) communication is possible.  This allows the cluster time to come up and become available.