### PR TITLE
ratel ingress update

### DIFF
--- a/charts/ratel/example_values/ingress/ingress-alb-no_host.yaml
+++ b/charts/ratel/example_values/ingress/ingress-alb-no_host.yaml
@@ -1,0 +1,16 @@
+# aws-load-balancer-controller
+# * https://github.com/kubernetes-sigs/aws-load-balancer-controller
+# NOTE: 
+#  * shared ALB with group name of 'dgraph' will be used.  
+#    This avoids provisioning multiple ALBs
+  enabled: true
+  className: alb
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/group: dgraph
+  hosts:
+    - paths:
+        - path: /*
+          pathType: ImplementationSpecific
+      host: ratel.example.com

--- a/charts/ratel/example_values/ingress/ingress-alb-with_host.yaml
+++ b/charts/ratel/example_values/ingress/ingress-alb-with_host.yaml
@@ -1,0 +1,10 @@
+ingress:
+  enabled: true
+  className: alb
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+  hosts:
+    - paths:
+        - path: /*
+          pathType: ImplementationSpecific

--- a/charts/ratel/templates/ingress.yaml
+++ b/charts/ratel/templates/ingress.yaml
@@ -38,8 +38,7 @@ spec:
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
+    - http:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
@@ -57,5 +56,8 @@ spec:
               servicePort: {{ $svcPort }}
               {{- end }}
           {{- end }}
+        {{- if .host }}
+        host: {{ .host | quote }}
+        {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
This fixes #98

Fix can be verified the following below.  An absent `host:` key means this works. 

```shell
helm template --namespace ratel --create-namespace ./charts/ratel/ --values - <<EOF
ingress:
  enabled: true
  className: alb
  annotations:
    alb.ingress.kubernetes.io/scheme: internet-facing
    alb.ingress.kubernetes.io/target-type: ip
  hosts:
    - paths:
        - path: /*
          pathType: ImplementationSpecific
EOF
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/99)
<!-- Reviewable:end -->
