### PR TITLE
Readiness/Liveliness changes

### DIFF
--- a/charts/dgraph/Chart.yaml
+++ b/charts/dgraph/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: dgraph
-version: 0.1.1
-appVersion: v23.0.0
+version: 0.2.0
+appVersion: v23.0.1
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:
 - dgraph

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -61,7 +61,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | ---------------------------------------- | --------------------------------------------------------------------- | --------------------------------------------------- |
 | `image.registry`                         | Container registry name                                               | `docker.io`                                         |
 | `image.repository`                       | Container image name                                                  | `dgraph/dgraph`                                     |
-| `image.tag`                              | Container image tag                                                   | `v23.0.0`                                           |
+| `image.tag`                              | Container image tag                                                   | `v23.0.1`                                           |
 | `image.pullPolicy`                       | Container pull policy                                                 | `IfNotPresent`                                      |
 | `nameOverride`                           | Deployment name override (will append the release name)               | `nil`                                               |
 | `fullnameOverride`                       | Deployment full name override (the release name is ignored)           | `nil`                                               |

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -67,7 +67,7 @@ zero:
   ## StatefulSet controller supports relax its ordering guarantees while preserving its uniqueness and identity guarantees. There are two valid pod management policies: OrderedReady and Parallel
   ## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy
   ##
-  podManagementPolicy: OrderedReady
+  podManagementPolicy: Parallel
 
   ## Number of dgraph zero pods
   ##
@@ -205,7 +205,7 @@ zero:
   readinessProbe:
     enabled: true
     port: 6080
-    path: /health
+    path: /state
     initialDelaySeconds: 15
     periodSeconds: 10
     timeoutSeconds: 5

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -10,7 +10,7 @@
 image: &image
   registry: docker.io
   repository: dgraph/dgraph
-  tag: v23.0.0
+  tag: v23.0.1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -193,7 +193,7 @@ zero:
     successThreshold: 1
 
   livenessProbe:
-    enabled: false
+    enabled: true
     port: 6080
     path: /health
     initialDelaySeconds: 15
@@ -203,7 +203,7 @@ zero:
     successThreshold: 1
 
   readinessProbe:
-    enabled: false
+    enabled: true
     port: 6080
     path: /health
     initialDelaySeconds: 15
@@ -247,7 +247,7 @@ alpha:
   ## StatefulSet controller supports relax its ordering guarantees while preserving its uniqueness and identity guarantees. There are two valid pod management policies: OrderedReady and Parallel
   ## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy
   ##
-  podManagementPolicy: OrderedReady
+  podManagementPolicy: Parallel
 
   ## Number of dgraph nodes
   ##
@@ -414,7 +414,7 @@ alpha:
     successThreshold: 1
 
   livenessProbe:
-    enabled: false
+    enabled: true
     port: 8080
     path: /health?live=1
     initialDelaySeconds: 15
@@ -424,9 +424,9 @@ alpha:
     successThreshold: 1
 
   readinessProbe:
-    enabled: false
+    enabled: true
     port: 8080
-    path: /health
+    path: /probe/graphql
     initialDelaySeconds: 15
     periodSeconds: 10
     timeoutSeconds: 5


### PR DESCRIPTION
The helm chart is going will now enable `livenessProbe` and `readinessProbe` on both Zero and Alpha.  The readiness check `readinessProbe.path` will use the undocumented `/probe/graphql` http path.  Note that this will take 30 seconds for the pod to be ready, which may lead to outage windows if 2/n+1 Alpha pods go down, especially in parallel mode.

### Summary of Changes

* `image.tag=v23.0.1`
* `alpha.podManagementPolicy=Parallel`
* `alpha.livenessProbe.enabled=true`
* `alpha.readinessProbe=true`
* `alpha.readinessProbe.path=/probe/graphql`
* `zero.livenessProbe.enabled=true`
* `zero.readinessProbe=true`
* README instructions

### Testing Instructions

```bash
git checkout git@github.com:dgraph-io/charts.git && cd charts && git checkout joaquin/readiness
# K8S cluster needs support for persistent volumes, e.g. EKS w. AWS EBS CSI driver
export KUBECONFIG="/path/to/my/k8s/config" # e.g. `~/.kube/minikube.yaml`
# deploy dgraph with new defaults
helm install my-release ./charts/dgraph
# Run Tests
# Example:
# * bulk or live loader while deleting 2 pods in the background 
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/101)
<!-- Reviewable:end -->
