### PR TITLE
Add option to use env variables with alpha init container and also en…

### DIFF
--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -129,10 +129,17 @@ spec:
       {{- end }}
       {{- if $initContainerEnabled }}
       initContainers:
+      {{- with .Values.alpha.extraInitContainers }}
+        {{- tpl (toYaml .) $ | nindent 6 }}
+      {{- end }}
       {{- if .Values.alpha.initContainers.init.enabled }}
       - name: {{ template "dgraph.alpha.fullname" . }}-init
         image: {{ template "dgraph.initContainers.init.image" . }}
         imagePullPolicy: {{ .Values.alpha.initContainers.init.image.pullPolicy | quote }}
+        env:
+        {{- with .Values.alpha.initContainers.init.env }}
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
         command:
         {{- range .Values.alpha.initContainers.init.command }}
           - {{ . | quote }}

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -437,6 +437,9 @@ alpha:
   customStartupProbe: {}
   customLivenessProbe: {}
   customReadinessProbe: {}
+  
+  # Enables extra init containers to be added to the alpha statefulset
+  extraInitContainers: []
 
   ## You may want to initialize the Alphas with data before starting Alpha containers.
   ## Examples can include:
@@ -446,6 +449,8 @@ alpha:
   initContainers:
     init:
       enabled: false
+      # Adds environment variables for the alpha init container
+      env: []
       image:
         << : *image
       command:


### PR DESCRIPTION
## What
- Add support for Env variables in alphas init container
- Add the "option" to use more than one init container if needed 

## Why 
- Alpha's init container is the best place to use if you want to initialize alpha with data before starting, e.g: using Bulk Loader.
- In most cases the data used in the Bulk loader will be stored in some object storage (S3, MinIO gateway...), It is natural that the access keys for these different destinations are stored in kubernetes secret and shouldn't be passed as plain text.
- Env variables also can make the code more generic if we have multiple feature branches/releases that uses the same script (e.g: Bulk loader) but with different parameters.

## Usage 
- Adding an Env variable is as easy as:
``` bash
alpha:
  initContainers:
     init:
       enabled: false
        # Adds environment variables for the alpha init container
        env: 
          - name: ENV_VAR_0
            valueFrom:
               secretKeyRef:
                 name: some-secret
                 key: some-key
           - name: ENV_VAR_1
             value: "foo"
``` 
- Add Extra init containers:
```bash
alpha:
  extraInitContainers: 
      - name: wait-for-zero-to-run
        image: dwdraju/alpine-curl-jq:latest
        env:
          - name: ZERO_HOST
            value: http://zero
        command: ['sh', '-c', " echo "wait for zero to be up and identify the zero leader to be used by the bulk loader" ]
      - name: run-bulkloader
        image: dgraph/dgraph
        command: ['sh', '-c', " echo "run bulk loader"]
```

- **NOTE**: `alpha.extraInitContainers` can be also used in conjunction with `alpha.initContainers` , where `alpha.initContainers`  will be the last init container to run.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/102)
<!-- Reviewable:end -->
