### PR TITLE
service account credential mount

### DIFF
--- a/charts/dgraph/Chart.yaml
+++ b/charts/dgraph/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dgraph
-version: 0.2.1
+version: 0.2.2
 appVersion: v23.0.1
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -68,8 +68,6 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `serviceAccount.create`                  | Create ServiceAccount                                                 | `true`                                              |
 | `serviceAccount.annotations`             | ServiceAccount annotations                                            | `{}`                                                |
 | `serviceAccount.name`                    | ServiceAccount name                                                   | `dgraph`                                            |
-| `serviceAccount.name`                    | ServiceAccount name                                                   | `dgraph`                                            |
-| `serviceAccount.name`                    | ServiceAccount name                                                   | `dgraph`                                            |
 | `serviceAccount.automountServiceAccountToken` | automatially mount a ServiceAccount API credentials              | `true`                                              |
 | `zero.name`                              | Zero component name                                                   | `zero`                                              |
 | `zero.metrics.enabled`                   | Add annotations for Prometheus metric scraping                        | `true`                                              |

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -68,6 +68,9 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `serviceAccount.create`                  | Create ServiceAccount                                                 | `true`                                              |
 | `serviceAccount.annotations`             | ServiceAccount annotations                                            | `{}`                                                |
 | `serviceAccount.name`                    | ServiceAccount name                                                   | `dgraph`                                            |
+| `serviceAccount.name`                    | ServiceAccount name                                                   | `dgraph`                                            |
+| `serviceAccount.name`                    | ServiceAccount name                                                   | `dgraph`                                            |
+| `serviceAccount.automountServiceAccountToken` | automatially mount a ServiceAccount API credentials              | `true`                                              |
 | `zero.name`                              | Zero component name                                                   | `zero`                                              |
 | `zero.metrics.enabled`                   | Add annotations for Prometheus metric scraping                        | `true`                                              |
 | `zero.extraAnnotations`                  | Specify annotations for template metadata                             | `{}`                                                |
@@ -86,6 +89,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `zero.extraEnvs`                         | extra env vars                                                        | `[]`                                                |
 | `zero.extraFlags`                        | Zero extra flags for command line                                     | `""`                                                |
 | `zero.configFile`                        | Zero config file                                                      | `{}`                                                |
+| `zero.automountServiceAccountToken`      | automatially mount a ServiceAccount API credentials                   | `true`                                              |
 | `zero.service.type`                      | Zero service type                                                     | `ClusterIP`                                         |
 | `zero.service.labels`                    | Zero service labels                                                   | `{}`                                                |
 | `zero.service.annotations`               | Zero service annotations                                              | `{}`                                                |
@@ -127,6 +131,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `alpha.extraEnvs`                        | extra env vars                                                        | `[]`                                                |
 | `alpha.extraFlags`                       | Alpha extra flags for command                                         | `""`                                                |
 | `alpha.configFile`                       | Alpha config file                                                     | `{}`                                                |
+| `alpha.automountServiceAccountToken`     | automatially mount a ServiceAccount API credentials                   | `true`                                              |
 | `alpha.service.type`                     | Alpha node service type                                               | `ClusterIP`                                         |
 | `alpha.service.labels`                   | Alpha service labels                                                  | `{}`                                                |
 | `alpha.service.annotations`              | Alpha service annotations                                             | `{}`                                                |
@@ -186,6 +191,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `ratel.replicaCount`                     | Number of ratel nodes                                                 | `1`                                                 |
 | `ratel.extraEnvs`                        | Extra env vars                                                        | `[]`                                                |
 | `ratel.args`                             | Ratel command line arguments                                          | `[]`                                                |
+| `ratel.automountServiceAccountToken`     | automatially mount a ServiceAccount API credentials                   | `true`                                              |
 | `ratel.service.type`                     | Ratel service type                                                    | `ClusterIP`                                         |
 | `ratel.service.labels`                   | Ratel Service labels                                                  | `{}`                                                |
 | `ratel.service.annotations`              | Ratel Service annotations                                             | `{}`                                                |

--- a/charts/dgraph/example_values/service_account.yaml
+++ b/charts/dgraph/example_values/service_account.yaml
@@ -1,0 +1,9 @@
+## serviceaccount
+## Specify that only Alpha pods automatically mount a ServiceAccount API credentials
+## * https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting
+serviceAccount:
+  automountServiceAccountToken: false
+zero:
+  automountServiceAccountToken: false
+alpha:
+  automountServiceAccountToken: true

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -79,6 +79,7 @@ spec:
     spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      automountServiceAccountToken: {{ .Values.alpha.automountServiceAccountToken }}
       {{- end }}
       {{- if .Values.alpha.schedulerName }}
       schedulerName: {{ .Values.alpha.schedulerName }}

--- a/charts/dgraph/templates/ratel/deployment.yaml
+++ b/charts/dgraph/templates/ratel/deployment.yaml
@@ -36,6 +36,7 @@ spec:
     spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      automountServiceAccountToken: {{ .Values.ratel.automountServiceAccountToken }}
       {{- end }}
       {{- if .Values.ratel.schedulerName }}
       schedulerName: {{ .Values.ratel.schedulerName }}

--- a/charts/dgraph/templates/serviceaccount.yaml
+++ b/charts/dgraph/templates/serviceaccount.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ .Values.serviceAccount.name }}
   labels:

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -72,6 +72,7 @@ spec:
     spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      automountServiceAccountToken: {{ .Values.zero.automountServiceAccountToken }}
       {{- end }}
       {{- if .Values.zero.schedulerName }}
       schedulerName: {{ .Values.zero.schedulerName }}

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -107,6 +107,10 @@ zero:
   ## Ref: https://dgraph.io/docs/deploy/config/
   configFile: {}
 
+  # automatically mount a ServiceAccount API credentials
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting
+  automountServiceAccountToken: true
+
   ## Kubernetes configuration
   ## For minikube, set this to NodePort, elsewhere use LoadBalancer
   ##
@@ -285,6 +289,10 @@ alpha:
   ## Configuration file for dgraph alpha used as an alternative to command-line options
   ## Ref: https://dgraph.io/docs/deploy/config/
   configFile: {}
+
+  # automatically mount a ServiceAccount API credentials
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting
+  automountServiceAccountToken: true
 
   ## Kubernetes configuration
   ## For minikube, set this to NodePort, elsewhere use LoadBalancer
@@ -496,6 +504,10 @@ ratel:
 
   # Arguments appended to a command dgraph-ratel command
   args: []
+
+  # automatically mount a ServiceAccount API credentials
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting
+  automountServiceAccountToken: true
 
   ## Kubernetes configuration
   ## For minikube, set this to NodePort, elsewhere use ClusterIP or LoadBalancer

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -36,6 +36,9 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: dgraph
+  # automatically mount a ServiceAccount API credentials
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting
+  automountServiceAccountToken: true
 
 zero:
   name: zero


### PR DESCRIPTION
This adds feature to toggle whether or not to mount service account token credentials for the service.  This can be implemented in the following places:

* serviceAccount.automountServiceAccountToken - default for all services
* alpha.automountServiceAccountToken - toggle for just alpha
* zero.automountServiceAccountToken - toggle for just zero
* ratel.automountServiceAccountToken - toggle for just ratel http host

There's an example to turn it off except for alpha at:

* example_files/service_account.yaml

This can be tested with:

```bash
helm template ./charts/dgraph \
 --values ./charts/dgraph/example_values/service_account.yaml
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/106)
<!-- Reviewable:end -->
