### PR TITLE
feat: allow tpl func in env for alpha init container

### DIFF
--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -137,9 +137,9 @@ spec:
       - name: {{ template "dgraph.alpha.fullname" . }}-init
         image: {{ template "dgraph.initContainers.init.image" . }}
         imagePullPolicy: {{ .Values.alpha.initContainers.init.image.pullPolicy | quote }}
-        env:
         {{- with .Values.alpha.initContainers.init.env }}
-          {{- toYaml . | nindent 12 }}
+        env:
+          {{- tpl (toYaml .) $ | nindent 10 }}
         {{- end }}
         command:
         {{- range .Values.alpha.initContainers.init.command }}


### PR DESCRIPTION
Gives opportunity to refer to the chart internals if needed, .e.g. using the following input
```yaml
alpha:
  initContainers:
    init:
      enabled: true
      env:
        - name: "RELEASE_NAME"
          value: "{{ .Release.Name }}"
        - name: "ZERO_SVC"
          value: "{{ template \"dgraph.zero.fullname\" . }}"
```
produces the output of
```yaml
    initContainers:
      - name: release-name-dgraph-alpha-init
        image: docker.io/dgraph/dgraph:v23.0.1
        imagePullPolicy: "IfNotPresent"
        env:
          - name: RELEASE_NAME
            value: 'release-name'
          - name: ZERO_SVC
            value: 'release-name-dgraph-zero'
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/charts/110)
<!-- Reviewable:end -->
