### PR TITLE
feat: add envFrom support

### DIFF
--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -84,6 +84,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `zero.antiAffinity`                      | Zero anti-affinity policy                                             | `soft`                                              |
 | `zero.podAntiAffinitytopologyKey`        | Anti affinity topology key for zero nodes                             | `kubernetes.io/hostname`                            |
 | `zero.nodeAffinity`                      | Zero node affinity policy                                             | `{}`                                                |
+| `zero.envFrom`                           | Extra environment variables loaded from configmap(s) and/or secret(s) | `[]`                                                |
 | `zero.extraEnvs`                         | extra env vars                                                        | `[]`                                                |
 | `zero.extraFlags`                        | Zero extra flags for command line                                     | `""`                                                |
 | `zero.configFile`                        | Zero config file                                                      | `{}`                                                |
@@ -126,6 +127,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `alpha.antiAffinity`                     | Alpha anti-affinity policy                                            | `soft`                                              |
 | `alpha.podAntiAffinitytopologyKey`       | Anti affinity topology key for zero nodes                             | `kubernetes.io/hostname`                            |
 | `alpha.nodeAffinity`                     | Alpha node affinity policy                                            | `{}`                                                |
+| `alpha.envFrom`                          | Extra environment variables loaded from configmap(s) and/or secret(s) | `[]`                                                |
 | `alpha.extraEnvs`                        | extra env vars                                                        | `[]`                                                |
 | `alpha.extraFlags`                       | Alpha extra flags for command                                         | `""`                                                |
 | `alpha.configFile`                       | Alpha config file                                                     | `{}`                                                |
@@ -176,6 +178,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `alpha.initContainers.init.image.tag`        | Alpha initContainer image tag                                     | `v21.03.0`                                          |
 | `alpha.initContainers.init.image.pullPolicy` | Alpha initContainer pull policy                                   | `IfNotPresent`                                      |
 | `alpha.initContainers.init.env` | Adds environment variables for the alpha init container                                  | `[]`                                      |
+| `alpha.initContainers.init.envFrom`      | Extra environment variables loaded from configmap(s) and/or secret(s) | `[]`                                                |
 | `alpha.initContainers.init.command`      | Alpha initContainer command line to execute                           | See `values.yaml` for defaults                      |
 | `ratel.name`                             | Ratel component name                                                  | `ratel`                                             |
 | `ratel.enabled`                          | Ratel service enabled or disabled                                     | `false`                                             |
@@ -187,6 +190,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `ratel.image.pullPolicy`                 | Container pull policy                                                 | `IfNotPresent`                                      |
 | `ratel.schedulerName`                    | Configure an explicit scheduler                                       | `nil`                                               |
 | `ratel.replicaCount`                     | Number of ratel nodes                                                 | `1`                                                 |
+| `ratel.envFrom`                          | Extra environment variables loaded from configmap(s) and/or secret(s) | `[]`                                                |
 | `ratel.extraEnvs`                        | Extra env vars                                                        | `[]`                                                |
 | `ratel.args`                             | Ratel command line arguments                                          | `[]`                                                |
 | `ratel.automountServiceAccountToken`     | automatially mount a ServiceAccount API credentials                   | `true`                                              |

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -141,6 +141,10 @@ spec:
         {{- with .Values.alpha.initContainers.init.env }}
           {{- toYaml . | nindent 12 }}
         {{- end }}
+        {{- with .Values.alpha.initContainers.init.envFrom }}
+        envFrom:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         command:
         {{- range .Values.alpha.initContainers.init.command }}
           - {{ . | quote }}
@@ -197,6 +201,10 @@ spec:
             value: /dgraph/config/{{ first (keys .Values.alpha.configFile | uniq | sortAlpha) }}
           {{- end }}
         {{- with .Values.alpha.extraEnvs }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.alpha.envFrom }}
+        envFrom:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         {{/* NOTE: awk '{gsub(/\.$/,"") needed to trim */}}

--- a/charts/dgraph/templates/ratel/deployment.yaml
+++ b/charts/dgraph/templates/ratel/deployment.yaml
@@ -57,6 +57,10 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- end }}
+        {{- with .Values.ratel.envFrom }}
+        envFrom:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         args: {{ .Values.ratel.args | toYaml | nindent 10 }}
         command:
           - dgraph-ratel

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -142,6 +142,10 @@ spec:
         {{- with .Values.zero.extraEnvs }}
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.zero.envFrom }}
+        envFrom:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         command:
           - bash
           - "-c"

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -97,6 +97,9 @@ zero:
   ## https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
   nodeAffinity: {}
 
+  ## Extra environment variables loaded from configmap(s) and/or secret(s)
+  envFrom: []
+
   ## Extra environment variables which will be appended to the env: definition for the container.
   extraEnvs: []
 
@@ -275,6 +278,9 @@ alpha:
   ## This is the node affinity settings as defined in
   ## https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
   nodeAffinity: {}
+
+  ## Extra environment variables loaded from configmap(s) and/or secret(s)
+  envFrom: []
 
   ## Extra environment variables which will be appended to the env: definition for the container.
   extraEnvs: []
@@ -462,6 +468,7 @@ alpha:
       enabled: false
       # Adds environment variables for the alpha init container
       env: []
+      envFrom: []
       image:
         << : *image
       command:
@@ -498,6 +505,9 @@ ratel:
   ## Number of dgraph nodes
   ##
   replicaCount: 1
+
+  ## Extra environment variables loaded from configmap(s) and/or secret(s)
+  envFrom: []
 
   # Extra environment variables which will be appended to the env: definition for the container.
   extraEnvs: []


### PR DESCRIPTION
Sometimes it's much easier to import environment variables from configmap(s) and/or secret(s) instead of duplicating every possible value.