### PR TITLE
fix: service account name formula

### DIFF
--- a/charts/dgraph/templates/_helpers.tpl
+++ b/charts/dgraph/templates/_helpers.tpl
@@ -179,6 +179,16 @@ Create a default fully qualified alpha name.
 {{ template "dgraph.fullname" . }}-{{ .Values.alpha.name }}
 {{- end -}}
 
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "dgraph.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "dgraph.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
 
 {{/*
 Create a default fully qualified ratel name.

--- a/charts/dgraph/templates/serviceaccount.yaml
+++ b/charts/dgraph/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ template "dgraph.serviceAccountName" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}


### PR DESCRIPTION
Currently, service name should be hardcoded to be properly rendered. This PR fixes such behavior according to the [comment](https://github.com/dgraph-io/charts/blob/master/charts/dgraph/values.yaml#L36-L37) in the values.