### PR TITLE
[ratel] feat: allow namespace override

### DIFF
--- a/charts/ratel/README.md
+++ b/charts/ratel/README.md
@@ -40,6 +40,7 @@ The following table lists the configurable parameters of the ratel chart and the
 | `image.tag`                              | Container image tag                                                   | `v21.12.0`                                          |
 | `imagePullSecrets`                       | Image pull secrets auth tokens used to access a private registry      | `[]`                                                |
 | `nameOverride`                           | Name override of the default chart name                               | `""`                                                |
+| `namespaceOverride`                      | Namespace override                                                    | `nil`                                               |
 | `fullnameOverride`                       | Full Name override of the release name + chart name                   | `""`                                                |
 | `serviceAccount.create`                  | Specifies if service account should be created                        | `true`                                              |
 | `serviceAccount.annotations`             | Service Account annotations                                           | `{}`                                                |

--- a/charts/ratel/templates/NOTES.txt
+++ b/charts/ratel/templates/NOTES.txt
@@ -6,17 +6,17 @@
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "ratel.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  export NODE_PORT=$(kubectl get --namespace {{ include "ratel.namespace" . }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "ratel.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ include "ratel.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "ratel.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "ratel.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+           You can watch the status of by running 'kubectl get --namespace {{ include "ratel.namespace" . }} svc -w {{ include "ratel.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ include "ratel.namespace" . }} {{ include "ratel.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "ratel.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  export POD_NAME=$(kubectl get pods --namespace {{ include "ratel.namespace" . }} -l "app.kubernetes.io/name={{ include "ratel.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ include "ratel.namespace" . }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8000 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8000:$CONTAINER_PORT
+  kubectl --namespace {{ include "ratel.namespace" . }} port-forward $POD_NAME 8000:$CONTAINER_PORT
 {{- end }}

--- a/charts/ratel/templates/_helpers.tpl
+++ b/charts/ratel/templates/_helpers.tpl
@@ -60,3 +60,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Allow overriding namespace
+*/}}
+{{- define "ratel.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride -}}
+{{- end -}}

--- a/charts/ratel/templates/deployment.yaml
+++ b/charts/ratel/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "ratel.fullname" . }}
+  namespace: {{ include "ratel.namespace" . }}
   labels:
     {{- include "ratel.labels" . | nindent 4 }}
 spec:

--- a/charts/ratel/templates/ingress.yaml
+++ b/charts/ratel/templates/ingress.yaml
@@ -16,6 +16,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ include "ratel.namespace" . }}
   labels:
     {{- include "ratel.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/ratel/templates/service.yaml
+++ b/charts/ratel/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ratel.fullname" . }}
+  namespace: {{ include "ratel.namespace" . }}
   labels:
     {{- include "ratel.labels" . | nindent 4 }}
 spec:

--- a/charts/ratel/templates/serviceaccount.yaml
+++ b/charts/ratel/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "ratel.serviceAccountName" . }}
+  namespace: {{ include "ratel.namespace" . }}
   labels:
     {{- include "ratel.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/ratel/templates/tests/test-connection.yaml
+++ b/charts/ratel/templates/tests/test-connection.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "ratel.fullname" . }}-test-connection"
+  namespace: {{ include "ratel.namespace" . }}
   labels:
     {{- include "ratel.labels" . | nindent 4 }}
   annotations:


### PR DESCRIPTION
Adds possibility to deploy resources in the namespace different from the release one, useful in scenarios with umbrella helm charts.