### PR TITLE
[dgraph] feat: allow namespace override

### DIFF
--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -64,6 +64,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `image.tag`                              | Container image tag                                                   | `v23.0.1`                                           |
 | `image.pullPolicy`                       | Container pull policy                                                 | `IfNotPresent`                                      |
 | `nameOverride`                           | Deployment name override (will append the release name)               | `nil`                                               |
+| `namespaceOverride`                      | Deployment namespace override if specified.                           | `nil`                                               |
 | `fullnameOverride`                       | Deployment full name override (the release name is ignored)           | `nil`                                               |
 | `serviceAccount.create`                  | Create ServiceAccount                                                 | `true`                                              |
 | `serviceAccount.annotations`             | ServiceAccount annotations                                            | `{}`                                                |

--- a/charts/dgraph/templates/NOTES.txt
+++ b/charts/dgraph/templates/NOTES.txt
@@ -21,21 +21,21 @@
 
 {{- else if contains "NodePort" .Values.alpha.service.type }}
 
-    export ALPHA_NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[?(@.name=='http-alpha')].nodePort}" services {{ include "dgraph.alpha.fullname" . }})
-    export ALPHA_NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    export ALPHA_NODE_PORT=$(kubectl get --namespace {{ include "dgraph.namespace" . }} -o jsonpath="{.spec.ports[?(@.name=='http-alpha')].nodePort}" services {{ include "dgraph.alpha.fullname" . }})
+    export ALPHA_NODE_IP=$(kubectl get nodes --namespace {{ include "dgraph.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
     echo "Access Alpha HTTP/S service using http://$ALPHA_NODE_IP:$ALPHA_NODE_PORT"
 {{- else if contains "LoadBalancer" .Values.alpha.service.type }}
    NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-         You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} service --watch {{ include "dgraph.alpha.fullname" . }}'
+         You can watch the status of by running 'kubectl get --namespace {{ include "dgraph.namespace" . }} service --watch {{ include "dgraph.alpha.fullname" . }}'
 
-    export ALPHA_SERVICE_IP=$(kubectl get service --namespace {{ .Release.Namespace }} {{ include "dgraph.alpha.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+    export ALPHA_SERVICE_IP=$(kubectl get service --namespace {{ include "dgraph.namespace" . }} {{ include "dgraph.alpha.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
     echo "Access Alpha HTTP/S service using http://$ALPHA_SERVICE_IP:8080"
 
 {{- else if contains "ClusterIP" .Values.alpha.service.type }}
 
-    export ALPHA_POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} --selector "statefulset.kubernetes.io/pod-name={{ include "dgraph.alpha.fullname" . }}-0,release={{ .Release.Name }}" --output jsonpath="{.items[0].metadata.name}")
+    export ALPHA_POD_NAME=$(kubectl get pods --namespace {{ include "dgraph.namespace" . }} --selector "statefulset.kubernetes.io/pod-name={{ include "dgraph.alpha.fullname" . }}-0,release={{ .Release.Name }}" --output jsonpath="{.items[0].metadata.name}")
     echo "Access Alpha HTTP/S using http://localhost:8080"
-    kubectl --namespace {{ .Release.Namespace }} port-forward $ALPHA_POD_NAME 8080:8080
+    kubectl --namespace {{ include "dgraph.namespace" . }} port-forward $ALPHA_POD_NAME 8080:8080
 
 {{- end }}
 
@@ -54,21 +54,21 @@
 
 {{- else if contains "NodePort" .Values.ratel.service.type }}
 
-    export RATEL_NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[?(@.name=='http-ratel')].nodePort}" services {{ include "dgraph.ratel.fullname" . }})
-    export RATEL_NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    export RATEL_NODE_PORT=$(kubectl get --namespace {{ include "dgraph.namespace" . }} -o jsonpath="{.spec.ports[?(@.name=='http-ratel')].nodePort}" services {{ include "dgraph.ratel.fullname" . }})
+    export RATEL_NODE_IP=$(kubectl get nodes --namespace {{ include "dgraph.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
     echo "Access Ratel HTTP/S service using http://$RATEL_NODE_IP:$RATEL_NODE_PORT"
 {{- else if contains "LoadBalancer" .Values.ratel.service.type }}
     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} service --watch {{ include "dgraph.ratel.fullname" . }}'
+           You can watch the status of by running 'kubectl get --namespace {{ include "dgraph.namespace" . }} service --watch {{ include "dgraph.ratel.fullname" . }}'
 
-    export RATEL_SERVICE_IP=$(kubectl get service --namespace {{ .Release.Namespace }} {{ include "dgraph.ratel.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+    export RATEL_SERVICE_IP=$(kubectl get service --namespace {{ include "dgraph.namespace" . }} {{ include "dgraph.ratel.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
     echo "Access Ratel HTTP/S service using http://$RATEL_SERVICE_IP"
 
 {{- else if contains "ClusterIP" .Values.ratel.service.type }}
 
-    export RATEL_POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} --selector "component={{ .Values.ratel.name }},release={{ .Release.Name }}" --output jsonpath="{.items[0].metadata.name}")
+    export RATEL_POD_NAME=$(kubectl get pods --namespace {{ include "dgraph.namespace" . }} --selector "component={{ .Values.ratel.name }},release={{ .Release.Name }}" --output jsonpath="{.items[0].metadata.name}")
     echo "Access Ratel HTTP/S using http://localhost:8000"
-    kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NARATEL_POD_NAMEME 8000:8000
+    kubectl --namespace {{ include "dgraph.namespace" . }} port-forward $POD_NARATEL_POD_NAMEME 8000:8000
 
 {{- end }}
 

--- a/charts/dgraph/templates/_helpers.tpl
+++ b/charts/dgraph/templates/_helpers.tpl
@@ -186,3 +186,10 @@ Create a default fully qualified ratel name.
 {{- define "dgraph.ratel.fullname" -}}
 {{ template "dgraph.fullname" . }}-{{ .Values.ratel.name }}
 {{- end -}}
+
+{{/*
+Allow overriding namespace
+*/}}
+{{- define "dgraph.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride -}}
+{{- end -}}

--- a/charts/dgraph/templates/alpha/configs.yaml
+++ b/charts/dgraph/templates/alpha/configs.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-config
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/alpha/ingress.yaml
+++ b/charts/dgraph/templates/alpha/ingress.yaml
@@ -22,6 +22,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-ingress
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}
@@ -67,6 +68,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-ingress-grpc
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/alpha/secret-acl.yaml
+++ b/charts/dgraph/templates/alpha/secret-acl.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-acl-secret
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/alpha/secret-enc.yaml
+++ b/charts/dgraph/templates/alpha/secret-enc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-encryption-secret
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/alpha/secret-tls.yaml
+++ b/charts/dgraph/templates/alpha/secret-tls.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-tls-secret
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -30,6 +30,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "dgraph.alpha.fullname" . }}
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/alpha/svc-headless.yaml
+++ b/charts/dgraph/templates/alpha/svc-headless.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-headless
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/alpha/svc.yaml
+++ b/charts/dgraph/templates/alpha/svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "dgraph.alpha.fullname" . }}
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/backups/configs.yaml
+++ b/charts/dgraph/templates/backups/configs.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "dgraph.backups.fullname" . }}-config
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/backups/cronjob-full.yaml
+++ b/charts/dgraph/templates/backups/cronjob-full.yaml
@@ -16,6 +16,7 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: {{ template "dgraph.backups.fullname" . }}-full
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/backups/cronjob-inc.yaml
+++ b/charts/dgraph/templates/backups/cronjob-inc.yaml
@@ -16,6 +16,7 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: {{ template "dgraph.backups.fullname" . }}-inc
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/backups/pv.yaml
+++ b/charts/dgraph/templates/backups/pv.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: {{ template "dgraph.backups.fullname" . }}-fileserver
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/backups/pvc.yaml
+++ b/charts/dgraph/templates/backups/pvc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ template "dgraph.backups.fullname" . }}-claim
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/backups/secrets.yaml
+++ b/charts/dgraph/templates/backups/secrets.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "dgraph.backups.fullname" . }}-secret
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/global-ingress.yaml
+++ b/charts/dgraph/templates/global-ingress.yaml
@@ -22,6 +22,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "dgraph.fullname" . }}-ingress
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}
@@ -80,6 +81,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "dgraph.fullname" . }}-ingress-grpc
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/ratel/deployment.yaml
+++ b/charts/dgraph/templates/ratel/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "dgraph.ratel.fullname" . }}
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/ratel/ingress.yaml
+++ b/charts/dgraph/templates/ratel/ingress.yaml
@@ -22,6 +22,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "dgraph.ratel.fullname" . }}-ingress
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/ratel/svc.yaml
+++ b/charts/dgraph/templates/ratel/svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "dgraph.ratel.fullname" . }}
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/serviceaccount.yaml
+++ b/charts/dgraph/templates/serviceaccount.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ .Values.serviceAccount.name }}
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/zero/configs.yaml
+++ b/charts/dgraph/templates/zero/configs.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "dgraph.zero.fullname" . }}-config
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/zero/secret-tls.yaml
+++ b/charts/dgraph/templates/zero/secret-tls.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "dgraph.zero.fullname" . }}-tls-secret
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -23,6 +23,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: "{{ template "dgraph.zero.fullname" . }}"
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/zero/svc-headless.yaml
+++ b/charts/dgraph/templates/zero/svc-headless.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "dgraph.zero.fullname" . }}-headless
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}

--- a/charts/dgraph/templates/zero/svc.yaml
+++ b/charts/dgraph/templates/zero/svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "dgraph.zero.fullname" . }}
+  namespace: {{ include "dgraph.namespace" . }}
   labels:
     app: {{ template "dgraph.name" . }}
     chart: {{ template "dgraph.chart" . }}


### PR DESCRIPTION
Adds possibility to deploy resources in the namespace different from the release one, useful in scenarios with umbrella helm charts.