### PR TITLE
bump dgraph and ratel chart versions

### DIFF
--- a/charts/dgraph/Chart.yaml
+++ b/charts/dgraph/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dgraph
-version: 0.2.2
+version: 0.3.0
 appVersion: v23.0.1
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:

--- a/charts/dgraph/Chart.yaml
+++ b/charts/dgraph/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: dgraph
 version: 0.3.0
-appVersion: v23.0.1
+appVersion: v23.1.0
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:
 - dgraph

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -61,7 +61,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | ---------------------------------------- | --------------------------------------------------------------------- | --------------------------------------------------- |
 | `image.registry`                         | Container registry name                                               | `docker.io`                                         |
 | `image.repository`                       | Container image name                                                  | `dgraph/dgraph`                                     |
-| `image.tag`                              | Container image tag                                                   | `v23.0.1`                                           |
+| `image.tag`                              | Container image tag                                                   | `v23.1.0`                                           |
 | `image.pullPolicy`                       | Container pull policy                                                 | `IfNotPresent`                                      |
 | `nameOverride`                           | Deployment name override (will append the release name)               | `nil`                                               |
 | `namespaceOverride`                      | Deployment namespace override if specified.                           | `nil`                                               |

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -10,7 +10,7 @@
 image: &image
   registry: docker.io
   repository: dgraph/dgraph
-  tag: v23.0.1
+  tag: v23.1.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/charts/ratel/Chart.yaml
+++ b/charts/ratel/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ratel/Chart.yaml
+++ b/charts/ratel/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.2.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v21.12.0"
+appVersion: "v23.1.0"


### PR DESCRIPTION
- Minor version bump for dgraph and ratel, as we are introducing a backward compatible API.
- Bump default dgraph version to v23.1.0