### PR TITLE
Updating Dgraph Charts to 24.0.2

### DIFF
--- a/charts/dgraph/Chart.yaml
+++ b/charts/dgraph/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: dgraph
-version: 0.3.0
-appVersion: v23.1.0
+version: 24.0.2
+appVersion: v24.0.2
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:
 - dgraph

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -61,7 +61,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | ---------------------------------------- | --------------------------------------------------------------------- | --------------------------------------------------- |
 | `image.registry`                         | Container registry name                                               | `docker.io`                                         |
 | `image.repository`                       | Container image name                                                  | `dgraph/dgraph`                                     |
-| `image.tag`                              | Container image tag                                                   | `v23.1.0`                                           |
+| `image.tag`                              | Container image tag                                                   | `v24.0.2`                                           |
 | `image.pullPolicy`                       | Container pull policy                                                 | `IfNotPresent`                                      |
 | `nameOverride`                           | Deployment name override (will append the release name)               | `nil`                                               |
 | `namespaceOverride`                      | Deployment namespace override if specified.                           | `nil`                                               |

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -10,7 +10,7 @@
 image: &image
   registry: docker.io
   repository: dgraph/dgraph
-  tag: v23.1.0
+  tag: v24.0.2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Updating dgraph chart versions to use 24.0.2
- Version bump for dgraph chart , aligning it with the application version 
-  Bump default dgraph version to v24.0.2