### PR TITLE
CronJob API version upgrade to batch/v1

### DIFF
--- a/charts/dgraph/templates/backups/cronjob-full.yaml
+++ b/charts/dgraph/templates/backups/cronjob-full.yaml
@@ -12,7 +12,7 @@
 {{- end -}}
 {{- end -}}
 {{- if .Values.backups.full.enabled -}}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ template "dgraph.backups.fullname" . }}-full

--- a/charts/dgraph/templates/backups/cronjob-inc.yaml
+++ b/charts/dgraph/templates/backups/cronjob-inc.yaml
@@ -12,7 +12,7 @@
 {{- end -}}
 {{- end -}}
 {{- if .Values.backups.incremental.enabled -}}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ template "dgraph.backups.fullname" . }}-inc


### PR DESCRIPTION
Installing the current helm chart Dgraph v24.0.5 failed if backup is enabled (using current Kubernetes v1.31):
`Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: resource mapping not found for name: "dgraph-cluster-1-dgraph-backups-inc" namespace: "prod" from "": no matches for kind "CronJob" in version "batch/v1beta1"
ensure CRDs are installed first`


The batch/v1beta1 API version of CronJob is no longer served as of v1.25.
[deprecation guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125)


Thanks
