### PR TITLE
fix: allow chart to be upgradable

### DIFF
--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -52,7 +52,6 @@ spec:
   selector:
     matchLabels:
       app: {{ template "dgraph.name" . }}
-      chart: {{ template "dgraph.chart" . }}
       release: {{ .Release.Name }}
       component: {{ .Values.alpha.name }}
   template:

--- a/charts/dgraph/templates/ratel/deployment.yaml
+++ b/charts/dgraph/templates/ratel/deployment.yaml
@@ -14,7 +14,6 @@ spec:
   selector:
     matchLabels:
       app: {{ template "dgraph.name" . }}
-      chart: {{ template "dgraph.chart" . }}
       component: {{ .Values.ratel.name }}
       release: {{ .Release.Name }}
   replicas: {{ .Values.ratel.replicaCount }}

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -45,7 +45,6 @@ spec:
   selector:
     matchLabels:
       app: {{ template "dgraph.name" . }}
-      chart: {{ template "dgraph.chart" . }}
       release: {{ .Release.Name }}
       component: {{ .Values.zero.name }}
   template:


### PR DESCRIPTION
Removes chart name/version from selector labels, which for StatefulSets are meant to be immutable. This seems to be what other chart maintainers have done, e.g. https://github.com/elastic/helm-charts/pull/622

see https://github.com/helm/charts/issues/7680

This fixes the following error when upgrading a helm release to a newer chart version:

```
- app_version: v25.0.0-preview6
  chart: dgraph-25.0.0-preview6
  description: 'Upgrade "dgraph" failed: cannot patch "dgraph-dgraph-ratel" with kind
    Deployment: Deployment.apps "dgraph-dgraph-ratel" is invalid: spec.selector: Invalid
    value: v1.LabelSelector{MatchLabels:map[string]string{"app":"dgraph", "chart":"dgraph-25.0.0-preview6",
    "component":"ratel", "release":"dgraph"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}:
    field is immutable && cannot patch "dgraph-dgraph-alpha" with kind StatefulSet:
    StatefulSet.apps "dgraph-dgraph-alpha" is invalid: spec: Forbidden: updates to
    statefulset spec for fields other than ''replicas'', ''ordinals'', ''template'',
    ''updateStrategy'', ''persistentVolumeClaimRetentionPolicy'' and ''minReadySeconds''
    are forbidden && cannot patch "dgraph-dgraph-zero" with kind StatefulSet: StatefulSet.apps
    "dgraph-dgraph-zero" is invalid: spec: Forbidden: updates to statefulset spec
    for fields other than ''replicas'', ''ordinals'', ''template'', ''updateStrategy'',
    ''persistentVolumeClaimRetentionPolicy'' and ''minReadySeconds'' are forbidden'
  revision: 6
  status: failed
  updated: "2025-09-18T22:17:57.424354119Z"
```

Still requires deleting StatefulSets (or running helm with `--force`?) for existing deployments though to remove the problematic label, I think.