### PR TITLE
fix: ensure backups via auth_token work

### DIFF
--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -589,7 +589,7 @@ When ACLs are used, the backup cronjob will log in to the Alpha node using a spe
 When a simple Auth Token is used, the backup cronjob script will submit an auth token when requesting a backup.
 
 * Alpha
-  * Alpha will need to be configured with environment variable `DGRAPH_ALPHA_AUTH_TOKEN` or configuration with `auth_token` set.
+  * Alpha will need to be configured with environment variable `DGRAPH_ALPHA_TOKEN` or configuration with `auth_token` set.
 * Backups
   * `backups.admin.auth_token` - this will need to have the same value configured in Alpha
 

--- a/charts/dgraph/templates/backups/cronjob-full.yaml
+++ b/charts/dgraph/templates/backups/cronjob-full.yaml
@@ -87,7 +87,7 @@ spec:
             - name: tls-volume
               mountPath: /dgraph/tls
             {{- end }}
-            {{- if .Values.alpha.acl.enabled }}
+            {{- if or .Values.alpha.acl.enabled .Values.backups.admin.auth_token }}
             - name: backup-secret-volume
               mountPath: /backup_secrets
             {{- end }}
@@ -126,7 +126,7 @@ spec:
             secret:
               secretName: {{ template "dgraph.alpha.fullname" . }}-tls-secret
           {{- end }}
-          {{- if or (.Values.alpha.acl.enabled) (.Values.backups.admin.auth_token) }}
+          {{- if or .Values.alpha.acl.enabled .Values.backups.admin.auth_token }}
           - name: backup-secret-volume
             secret:
               secretName: {{ template "dgraph.backups.fullname" . }}-secret

--- a/charts/dgraph/templates/backups/cronjob-inc.yaml
+++ b/charts/dgraph/templates/backups/cronjob-inc.yaml
@@ -87,7 +87,7 @@ spec:
             - name: tls-volume
               mountPath: /dgraph/tls
             {{- end }}
-            {{- if .Values.alpha.acl.enabled }}
+            {{- if or .Values.alpha.acl.enabled .Values.backups.admin.auth_token }}
             - name: backup-secret-volume
               mountPath: /backup_secrets
             {{- end }}


### PR DESCRIPTION
Fixes the following error in backup jobs when attempting to run backups using Dgraph-AuthToken w/o ACL:

```
cat: /backup_secrets/backup_auth_token: No such file or directory
```