### PR TITLE
Fix v24 to v25 upgrade path and bump chart to 25.3.1-preview1

### DIFF
--- a/charts/dgraph/Chart.yaml
+++ b/charts/dgraph/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: dgraph
-version: 25.0.0-preview6
-appVersion: v25.0.0-preview6
+version: 25.3.1-preview1
+appVersion: v25.3.1
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:
 - dgraph

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -22,6 +22,31 @@ Kubernetes cluster using [Helm](https://helm.sh) package manager.
 - Kubernetes 1.16+
 - Helm 3.0+
 
+### Upgrading
+
+#### v24.x to v25.x (Breaking Changes)
+
+Chart v25 removes the version-specific `chart` label from StatefulSet, Deployment, and Service selectors. This is a breaking change because Kubernetes does not allow modifying `selector.matchLabels` on existing StatefulSets and Deployments.
+
+**Automated migration**: Chart v25.3.1-preview1 and later include a `pre-upgrade` hook that automatically handles this. The hook:
+
+1. Detects StatefulSets and Deployments that still have the old `chart` selector label
+2. Deletes them with `--cascade=orphan`, which keeps existing pods running
+3. Helm then recreates the resources with the updated selectors and rolls the pods
+
+No manual intervention is required if you are upgrading to v25.3.1-preview1 or later.
+
+**Manual migration** (for earlier v25 chart versions without the hook):
+
+```bash
+# Delete StatefulSets while keeping pods running
+kubectl delete statefulset <release>-dgraph-alpha --cascade=orphan -n <namespace>
+kubectl delete statefulset <release>-dgraph-zero --cascade=orphan -n <namespace>
+
+# Then run the Helm upgrade
+helm upgrade <release> dgraph/dgraph --version <v25-version>
+```
+
 ### Installing the Chart
 
 To install the chart with the release name `my-release`:

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -39,12 +39,16 @@ No manual intervention is required if you are upgrading to v25.3.1-preview1 or l
 **Manual migration** (for earlier v25 chart versions without the hook):
 
 ```bash
+RELEASE="my-release"
+NAMESPACE="default"
+VERSION="25.3.1-preview1"
+
 # Delete StatefulSets while keeping pods running
-kubectl delete statefulset <release>-dgraph-alpha --cascade=orphan -n <namespace>
-kubectl delete statefulset <release>-dgraph-zero --cascade=orphan -n <namespace>
+kubectl delete statefulset "$RELEASE-dgraph-alpha" --cascade=orphan -n "$NAMESPACE"
+kubectl delete statefulset "$RELEASE-dgraph-zero" --cascade=orphan -n "$NAMESPACE"
 
 # Then run the Helm upgrade
-helm upgrade <release> dgraph/dgraph --version <v25-version>
+helm upgrade "$RELEASE" dgraph/dgraph --version "$VERSION"
 ```
 
 ### Installing the Chart

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -26,7 +26,9 @@ Kubernetes cluster using [Helm](https://helm.sh) package manager.
 
 #### v24.x to v25.x (Breaking Changes)
 
-Chart v25 removes the version-specific `chart` label from StatefulSet, Deployment, and Service selectors. This is a breaking change because Kubernetes does not allow modifying `selector.matchLabels` on existing StatefulSets and Deployments.
+Chart v25 removes the version-specific `chart` label (e.g. `chart: dgraph-24.1.4`) from StatefulSet, Deployment, and Service selectors. This is a one-time breaking change because Kubernetes does not allow modifying `selector.matchLabels` on existing StatefulSets and Deployments.
+
+Note that keeping the `chart` label in selectors was already problematic — because it includes the chart version, **every chart upgrade would change the selector value and break**, not just the v24 to v25 transition. Removing it ensures that future chart upgrades will work seamlessly without requiring resource recreation.
 
 **Automated migration**: Chart v25.3.1-preview1 and later include a `pre-upgrade` hook that automatically handles this. The hook:
 

--- a/charts/dgraph/templates/alpha/svc-headless.yaml
+++ b/charts/dgraph/templates/alpha/svc-headless.yaml
@@ -21,7 +21,6 @@ spec:
       targetPort: 7080
   selector:
     app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.alpha.name }}
     release: {{ .Release.Name }}
   publishNotReadyAddresses: {{ .Values.alpha.service.publishNotReadyAddresses }}

--- a/charts/dgraph/templates/alpha/svc.yaml
+++ b/charts/dgraph/templates/alpha/svc.yaml
@@ -37,6 +37,5 @@ spec:
   {{- end }}
   selector:
     app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.alpha.name }}
     release: {{ .Release.Name }}

--- a/charts/dgraph/templates/pre-upgrade-statefulset-cleanup.yaml
+++ b/charts/dgraph/templates/pre-upgrade-statefulset-cleanup.yaml
@@ -1,0 +1,119 @@
+{{/*
+Pre-upgrade hook: delete StatefulSets with --cascade=orphan so that Helm can
+recreate them with updated immutable fields (e.g. selector.matchLabels) while
+keeping existing pods running. The pods are adopted by the new StatefulSets
+once the upgrade completes.
+*/}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "dgraph.fullname" . }}-pre-upgrade
+  namespace: {{ include "dgraph.namespace" . }}
+  labels:
+    app: {{ template "dgraph.name" . }}
+    chart: {{ template "dgraph.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "dgraph.fullname" . }}-pre-upgrade
+  namespace: {{ include "dgraph.namespace" . }}
+  labels:
+    app: {{ template "dgraph.name" . }}
+    chart: {{ template "dgraph.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "deployments"]
+    verbs: ["get", "list", "watch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "dgraph.fullname" . }}-pre-upgrade
+  namespace: {{ include "dgraph.namespace" . }}
+  labels:
+    app: {{ template "dgraph.name" . }}
+    chart: {{ template "dgraph.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "dgraph.fullname" . }}-pre-upgrade
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "dgraph.fullname" . }}-pre-upgrade
+    namespace: {{ include "dgraph.namespace" . }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "dgraph.fullname" . }}-pre-upgrade
+  namespace: {{ include "dgraph.namespace" . }}
+  labels:
+    app: {{ template "dgraph.name" . }}
+    chart: {{ template "dgraph.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      name: {{ template "dgraph.fullname" . }}-pre-upgrade
+    spec:
+      serviceAccountName: {{ template "dgraph.fullname" . }}-pre-upgrade
+      restartPolicy: Never
+      {{- with .Values.alpha.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: pre-upgrade
+          image: bitnami/kubectl:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              NS="{{ include "dgraph.namespace" . }}"
+
+              # StatefulSets (Alpha and Zero)
+              for STS in {{ template "dgraph.alpha.fullname" . }} {{ template "dgraph.zero.fullname" . }}; do
+                SELECTOR=$(kubectl get statefulset "$STS" -n "$NS" -o jsonpath='{.spec.selector.matchLabels.chart}' 2>/dev/null)
+                if [ -n "$SELECTOR" ]; then
+                  echo "StatefulSet $STS has stale 'chart' selector label ($SELECTOR), deleting with --cascade=orphan..."
+                  kubectl delete statefulset "$STS" --cascade=orphan -n "$NS"
+                else
+                  echo "StatefulSet $STS does not have 'chart' selector label, skipping."
+                fi
+              done
+
+              # Deployments (Ratel)
+              for DEPLOY in {{ template "dgraph.ratel.fullname" . }}; do
+                SELECTOR=$(kubectl get deployment "$DEPLOY" -n "$NS" -o jsonpath='{.spec.selector.matchLabels.chart}' 2>/dev/null)
+                if [ -n "$SELECTOR" ]; then
+                  echo "Deployment $DEPLOY has stale 'chart' selector label ($SELECTOR), deleting with --cascade=orphan..."
+                  kubectl delete deployment "$DEPLOY" --cascade=orphan -n "$NS"
+                else
+                  echo "Deployment $DEPLOY does not have 'chart' selector label, skipping."
+                fi
+              done

--- a/charts/dgraph/templates/ratel/svc.yaml
+++ b/charts/dgraph/templates/ratel/svc.yaml
@@ -35,7 +35,6 @@ spec:
   {{- end }}
   selector:
     app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.ratel.name }}
     release: {{ .Release.Name }}
 

--- a/charts/dgraph/templates/zero/svc-headless.yaml
+++ b/charts/dgraph/templates/zero/svc-headless.yaml
@@ -21,7 +21,6 @@ spec:
       targetPort: 5080
   selector:
     app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     release: {{ .Release.Name }}
     component: {{ .Values.zero.name }}
   publishNotReadyAddresses: {{ .Values.zero.service.publishNotReadyAddresses }}

--- a/charts/dgraph/templates/zero/svc.yaml
+++ b/charts/dgraph/templates/zero/svc.yaml
@@ -38,6 +38,5 @@ spec:
   {{- end }}
   selector:
     app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     release: {{ .Release.Name }}
     component: {{ .Values.zero.name }}


### PR DESCRIPTION
## Summary

The v25 chart removed the `chart` label from StatefulSet and Deployment `selector.matchLabels` but missed removing it from Service selectors. This causes two problems when upgrading from v24:

1. **StatefulSet/Deployment selectors are immutable** — Kubernetes rejects the upgrade with `spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'ordinals', 'template', ...`
2. **Services can't discover pods** — after upgrade, Services still select on `chart: dgraph-25.x` but pods created by the new StatefulSets no longer match because the version-specific label value changed

### Changes

- **Pre-upgrade hook Job** (`templates/pre-upgrade-statefulset-cleanup.yaml`): detects StatefulSets and Deployments with the stale `chart` selector label and deletes them with `--cascade=orphan` before the upgrade. Pods keep running and are adopted by the recreated resources. Skips resources that are already on the v25 schema.
- **Service selector fixes**: removed `chart` from selectors in all 5 Services (alpha, alpha-headless, zero, zero-headless, ratel) to match the StatefulSet/Deployment changes
- **Chart version**: bumped to `25.3.1-preview1`, appVersion to `v25.3.1`

### Tested

- Fresh install of v24 chart (`24.1.4`), then in-place upgrade to this chart
- Pre-upgrade Job correctly deletes StatefulSets with `--cascade=orphan`
- New StatefulSets created with updated selectors
- Services discover pods immediately after upgrade
- All DGraph nodes connect to each other and cluster is healthy