### PR TITLE
Overhaul chart labels, harden pre-upgrade hook, fix docs and bugs

### DIFF
--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -108,7 +108,7 @@ To publish the chart, commit and push the latest changes of index file to `gh-pa
 
 ```bash
 git add index.yaml
-## cample commit strings:
+## example commit strings:
 ##   dgraph-lambda-0.0.1 index.yaml update
 ##   dgraph-0.0.13 index.yaml update
 git commit -m "chart-version index.yaml update"

--- a/charts/dgraph-lambda/README.md
+++ b/charts/dgraph-lambda/README.md
@@ -37,7 +37,7 @@ export DGRAPH_REL=my-release
 
 #### Deploy Dgraph Alpha
 
-Dgraph Alpha needs to be configured with the `--graphql lambda-url=<url>` argument (see: [lambda server](https://dgraph.io/docs/graphql/lambda/server/)) to support `dgraph-lambda`.  You can use environment variables to configure this:
+Dgraph Alpha needs to be configured with the `--graphql lambda-url=<url>` argument (see: [lambda server](https://docs.dgraph.io/installation/lambda-server)) to support `dgraph-lambda`.  You can use environment variables to configure this:
 
 ```bash
 helm install $DGRAPH_REL dgraph/dgraph \

--- a/charts/dgraph-lambda/README.md
+++ b/charts/dgraph-lambda/README.md
@@ -93,7 +93,7 @@ script:
 
 #### Deploy Dgraph Lambda
 
-We can deploy the example above, named `my-lambda.yaml`, with the follwing:
+We can deploy the example above, named `my-lambda.yaml`, with the following:
 
 ```bash
 helm install $LAMBDA_REL dgraph/dgraph-lambda \

--- a/charts/dgraph-lambda/values.yaml
+++ b/charts/dgraph-lambda/values.yaml
@@ -30,7 +30,7 @@ env:
   - name: DGRAPH_URL
     value: ""
   ## DGRAPH_TOKEN is set for X-Auth-Token
-  ## See: https://dgraph.io/docs/slash-graphql/admin/authentication/
+  ## See: https://docs.dgraph.io/admin/security/admin-endpoint-security
   # - name: DGRAPH_TOKEN
   #   value: ""
   # - name: NODE_ENV

--- a/charts/dgraph/.helmignore
+++ b/charts/dgraph/.helmignore
@@ -1,0 +1,26 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# Chart development extras
+example_values/
+scripts/

--- a/charts/dgraph/Chart.yaml
+++ b/charts/dgraph/Chart.yaml
@@ -1,6 +1,7 @@
-apiVersion: v1
+apiVersion: v2
 name: dgraph
-version: 25.3.1-preview1
+type: application
+version: 25.3.1-preview2
 appVersion: v25.3.1
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -664,4 +664,4 @@ done
 Dgraph exposes Prometheus metrics to monitor the state of various components involved in
 the cluster, this includes Dgraph Alpha and Dgraph Zero.
 
-Further information can be found in the [Monitoring in Kubernetes](https://dgraph.io/docs/deploy/installation/kubernetes/monitoring-cluster#monitoring-the-kubernetes-cluster) documentation.
+Further information can be found in the [Monitoring in Kubernetes](https://docs.dgraph.io/admin/observability/monitoring) documentation.

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -36,14 +36,14 @@ Note that keeping the `chart` label in selectors was already problematic — bec
 2. Deletes them with `--cascade=orphan`, which keeps existing pods running
 3. Helm then recreates the resources with the updated selectors and rolls the pods
 
-No manual intervention is required if you are upgrading to v25.3.1-preview1 or later.
+No manual intervention is required if you are upgrading to v25.3.1-preview1 or later. If upgrading to v25.3.1-preview2+, also review the [v25.3.1-preview2 breaking changes](#v2531-preview2-breaking-changes) below.
 
 **Manual migration** (for earlier v25 chart versions without the hook):
 
 ```bash
 RELEASE="my-release"
 NAMESPACE="default"
-VERSION="25.3.1-preview1"
+VERSION="25.3.1-preview2"
 
 # Delete StatefulSets while keeping pods running
 kubectl delete statefulset "$RELEASE-dgraph-alpha" --cascade=orphan -n "$NAMESPACE"

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -564,7 +564,7 @@ helm install $RELNAME \
 
 ## Binary backups
 
-Dgraph [Binary Backups](https://dgraph.io/docs/binary-backups/) are supported by Kubernetes CronJobs. There are two types of Kubernetes CronJobs supported:
+Dgraph [Binary Backups](https://docs.dgraph.io/admin/admin-tasks/binary-backups) are supported by Kubernetes CronJobs. There are two types of Kubernetes CronJobs supported:
 
 * Full backup at midnight: `0 * * * *`
 * Incremental backups every hour, except midnight: `0 1-23 * * *`

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -30,30 +30,15 @@ Chart v25 removes the version-specific `chart` label (e.g. `chart: dgraph-24.1.4
 
 Note that keeping the `chart` label in selectors was already problematic — because it includes the chart version, **every chart upgrade would change the selector value and break**, not just the v24 to v25 transition. Removing it ensures that future chart upgrades will work seamlessly without requiring resource recreation.
 
-**Automated migration**: Chart v25.3.1-preview1 and later include a `pre-upgrade` hook that automatically handles this. The hook:
+**Automated migration**: The chart includes a `pre-upgrade` hook that automatically handles this. The hook:
 
 1. Detects StatefulSets and Deployments that still have the old `chart` selector label
 2. Deletes them with `--cascade=orphan`, which keeps existing pods running
 3. Helm then recreates the resources with the updated selectors and rolls the pods
 
-No manual intervention is required if you are upgrading to v25.3.1-preview1 or later. If upgrading to v25.3.1-preview2+, also review the [v25.3.1-preview2 breaking changes](#v2531-preview2-breaking-changes) below.
+No manual intervention is required. Also review the [additional breaking changes](#additional-v25-breaking-changes) below.
 
-**Manual migration** (for earlier v25 chart versions without the hook):
-
-```bash
-RELEASE="my-release"
-NAMESPACE="default"
-VERSION="25.3.1-preview2"
-
-# Delete StatefulSets while keeping pods running
-kubectl delete statefulset "$RELEASE-dgraph-alpha" --cascade=orphan -n "$NAMESPACE"
-kubectl delete statefulset "$RELEASE-dgraph-zero" --cascade=orphan -n "$NAMESPACE"
-
-# Then run the Helm upgrade
-helm upgrade "$RELEASE" dgraph/dgraph --version "$VERSION"
-```
-
-#### v25.3.1-preview2 (Breaking Changes)
+#### Additional v25 breaking changes
 
 **Full backup restartPolicy fix**: The full backup CronJob previously read its `restartPolicy` from `backups.incremental.restartPolicy` instead of `backups.full.restartPolicy`. This has been fixed. If you were working around this bug by setting `backups.incremental.restartPolicy` to control the full backup's restart policy, you will need to move that value to `backups.full.restartPolicy`.
 

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -53,6 +53,12 @@ kubectl delete statefulset "$RELEASE-dgraph-zero" --cascade=orphan -n "$NAMESPAC
 helm upgrade "$RELEASE" dgraph/dgraph --version "$VERSION"
 ```
 
+#### v25.3.1-preview2 (Breaking Changes)
+
+**Full backup restartPolicy fix**: The full backup CronJob previously read its `restartPolicy` from `backups.incremental.restartPolicy` instead of `backups.full.restartPolicy`. This has been fixed. If you were working around this bug by setting `backups.incremental.restartPolicy` to control the full backup's restart policy, you will need to move that value to `backups.full.restartPolicy`.
+
+**Backup admin password now required**: When `alpha.acl.enabled` is true and backups are enabled, `backups.admin.password` must be explicitly set. Previously the chart would silently render an empty secret, which would cause backup failures at runtime. The chart now fails at install/upgrade time with a clear error message if the password is missing.
+
 ### Installing the Chart
 
 To install the chart with the release name `my-release`:

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -186,10 +186,10 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `alpha.securityContext.runAsUser`        | User ID for the Alpha container                                       | `1001`                                              |
 | `alpha.tls.enabled`                      | Alpha service TLS enabled                                             | `false`                                             |
 | `alpha.tls.files`                        | Alpha service TLS key and certificate files stored as secrets         | `false`                                             |
-| `alpha.encryption.enabled`               | Alpha Encryption at Rest enabled (Enterprise feature)                 | `false`                                             |
-| `alpha.encryption.file`                  | Alpha Encryption at Rest key file (Enterprise feature)                | `nil`                                               |
-| `alpha.acl.enabled`                      | Alpha ACL enabled (Enterprise feature)                                | `false`                                             |
-| `alpha.acl.file`                         | Alpha ACL secret file (Enterprise feature)                            | `nil`                                               |
+| `alpha.encryption.enabled`               | Alpha Encryption at Rest enabled                                      | `false`                                             |
+| `alpha.encryption.file`                  | Alpha Encryption at Rest key file                                     | `nil`                                               |
+| `alpha.acl.enabled`                      | Alpha ACL enabled                                                     | `false`                                             |
+| `alpha.acl.file`                         | Alpha ACL secret file                                                 | `nil`                                               |
 | `alpha.persistence.enabled`              | Enable persistence for alpha using PVC                                | `true`                                              |
 | `alpha.persistence.storageClass`         | PVC Storage Class for alpha volume                                    | `nil`                                               |
 | `alpha.persistence.accessModes`          | PVC Access Mode for alpha volume                                      | `['ReadWriteOnce']`                                 |
@@ -461,7 +461,7 @@ curl --silent \
   https://localhost:6080/state
 ```
 
-## Alpha encryption at rest (enterprise feature)
+## Alpha encryption at rest
 
 You can generate a secret for the key file using `base64` tool:
 
@@ -505,7 +505,7 @@ helm install $RELNAME \
  dgraph/dgraph
 ```
 
-## Alpha access control lists (enterprise feature)
+## Alpha access control lists
 
 You can generate a secret for the secrets file using `base64` tool:
 
@@ -549,9 +549,9 @@ helm install $RELNAME \
  dgraph/dgraph
 ```
 
-## Binary backups (enterprise feature)
+## Binary backups
 
-Dgraph [Binary Backups](https://dgraph.io/docs/enterprise-features/binary-backups/) are supported by Kubernetes CronJobs. There are two types of Kubernetes CronJobs supported:
+Dgraph [Binary Backups](https://dgraph.io/docs/binary-backups/) are supported by Kubernetes CronJobs. There are two types of Kubernetes CronJobs supported:
 
 * Full backup at midnight: `0 * * * *`
 * Incremental backups every hour, except midnight: `0 1-23 * * *`
@@ -610,7 +610,7 @@ If Dgraph Alpha TLS options are used, backup cronjobs will submit the requests u
 When ACLs are used, the backup cronjob will log in to the Alpha node using a specified user account.  Through this process, the backup cronjob script will receive an AccessJWT token that will be submitted when requesting a backup.
 
 * Alpha
-  * see [Alpha Access Control Lists](#alpha-access-control-lists-enterprise-feature) above.
+  * see [Alpha Access Control Lists](#alpha-access-control-lists) above.
 * Backups
   * `backups.admin.user` (default: `groot`) - a user that is a member of `guardians` group will need to be specified.
   * `backups.admin.password` (default: `password`) - the corresponding password for that user will need to be specified.

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -84,7 +84,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `commonLabels`                           | Labels to add to all resources and pod templates                      | `{}`                                                |
 | `image.registry`                         | Container registry name                                               | `docker.io`                                         |
 | `image.repository`                       | Container image name                                                  | `dgraph/dgraph`                                     |
-| `image.tag`                              | Container image tag                                                   | `v24.1.4`                                           |
+| `image.tag`                              | Container image tag                                                   | `v25.3.1`                                           |
 | `image.pullPolicy`                       | Container pull policy                                                 | `IfNotPresent`                                      |
 | `nameOverride`                           | Deployment name override (will append the release name)               | `nil`                                               |
 | `namespaceOverride`                      | Deployment namespace override if specified.                           | `nil`                                               |
@@ -248,7 +248,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `backups.podAnnotations`                 | Annotations for backup CronJob pods                                   | `{}`                                                |
 | `backups.schedulerName`                  | Configure an explicit scheduler for Backups Kubernetes CronJobs       | `nil`                                               |
 | `backups.admin.user`                     | Login user for backups (required if ACL enabled)                      | `groot`                                             |
-| `backups.admin.password`                 | Login user password for backups (required if ACL enabled)             | `password`                                          |
+| `backups.admin.password`                 | Login user password for backups (required if ACL enabled)             | `nil`                                               |
 | `backups.admin.tls_client`               | TLS Client Name (requried if `REQUIREANY` or `REQUIREANDVERIFY` set)  | `nil`                                               |
 | `backups.admin.auth_token`               | Auth Token                                                            | `nil`                                               |
 | `backups.image.registry`                 | Container registry name                                               | `docker.io`                                         |
@@ -611,7 +611,7 @@ When ACLs are used, the backup cronjob will log in to the Alpha node using a spe
   * see [Alpha Access Control Lists](#alpha-access-control-lists) above.
 * Backups
   * `backups.admin.user` (default: `groot`) - a user that is a member of `guardians` group will need to be specified.
-  * `backups.admin.password` (default: `password`) - the corresponding password for that user will need to be specified.
+  * `backups.admin.password` (required) - the corresponding password for that user will need to be specified.
 
 ### Using an auth token
 

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -90,6 +90,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 
 |              Parameter                   |                             Description                               |                       Default                       |
 | ---------------------------------------- | --------------------------------------------------------------------- | --------------------------------------------------- |
+| `commonLabels`                           | Labels to add to all resources and pod templates                      | `{}`                                                |
 | `image.registry`                         | Container registry name                                               | `docker.io`                                         |
 | `image.repository`                       | Container image name                                                  | `dgraph/dgraph`                                     |
 | `image.tag`                              | Container image tag                                                   | `v24.1.4`                                           |
@@ -97,6 +98,11 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `nameOverride`                           | Deployment name override (will append the release name)               | `nil`                                               |
 | `namespaceOverride`                      | Deployment namespace override if specified.                           | `nil`                                               |
 | `fullnameOverride`                       | Deployment full name override (the release name is ignored)           | `nil`                                               |
+| `preUpgradeHook.image.registry`          | Pre-upgrade hook image registry                                       | `docker.io`                                         |
+| `preUpgradeHook.image.repository`        | Pre-upgrade hook image repository                                     | `bitnami/kubectl`                                   |
+| `preUpgradeHook.image.tag`               | Pre-upgrade hook image tag                                            | `1.31`                                              |
+| `preUpgradeHook.podLabels`               | Labels for pre-upgrade hook Job pods                                  | `{}`                                                |
+| `preUpgradeHook.podAnnotations`          | Annotations for pre-upgrade hook Job pods                             | `{}`                                                |
 | `serviceAccount.create`                  | Create ServiceAccount                                                 | `true`                                              |
 | `serviceAccount.annotations`             | ServiceAccount annotations                                            | `{}`                                                |
 | `serviceAccount.name`                    | ServiceAccount name                                                   | `dgraph`                                            |
@@ -107,7 +113,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `zero.podLabels`                         | Specify additional labels for template metadata                       | `{}`                                                |
 | `zero.updateStrategy`                    | Strategy for upgrading zero nodes                                     | `RollingUpdate`                                     |
 | `zero.schedulerName`                     | Configure an explicit scheduler                                       | `nil`                                               |
-| `zero.monitorLabel`                      | Monitor label for zero, used by prometheus.                           | `zero-dgraph-io`                                    |
+| `zero.monitorLabel`                      | "monitor" label on the zero Service (for Prometheus service discovery) | `zero-dgraph-io`                                    |
 | `zero.rollingUpdatePartition`            | Partition update strategy                                             | `nil`                                               |
 | `zero.podManagementPolicy`               | Pod management policy for zero nodes                                  | `OrderedReady`                                      |
 | `zero.replicaCount`                      | Number of zero nodes                                                  | `3`                                                 |
@@ -149,7 +155,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `alpha.metrics.enabled`                  | Add annotations for Prometheus metric scraping                        | `true`                                              |
 | `alpha.extraAnnotations`                 | Specify annotations for template metadata                             | `{}`                                                |
 | `alpha.podLabels`                        | Specify additional labels for template metadata                       | `{}`                                                |
-| `alpha.monitorLabel`                     | Monitor label for alpha, used by prometheus.                          | `alpha-dgraph-io`                                   |
+| `alpha.monitorLabel`                     | "monitor" label on the alpha Service (for Prometheus service discovery) | `alpha-dgraph-io`                                   |
 | `alpha.updateStrategy`                   | Strategy for upgrading alpha nodes                                    | `RollingUpdate`                                     |
 | `alpha.schedulerName`                    | Configure an explicit scheduler                                       | `nil`                                               |
 | `alpha.rollingUpdatePartition`           | Partition update strategy                                             | `nil`                                               |
@@ -248,6 +254,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `ratel.customReadinessProbe`             | Ratel custom readiness probes (if `ratel.readinessProbe` not enabled) | `{}`                                                |
 | `backups.name`                           | Backups component name                                                | `backups`                                           |
 | `backups.podLabels`                      | Specify additional labels for template metadata                       | `{}`                                                |
+| `backups.podAnnotations`                 | Annotations for backup CronJob pods                                   | `{}`                                                |
 | `backups.schedulerName`                  | Configure an explicit scheduler for Backups Kubernetes CronJobs       | `nil`                                               |
 | `backups.admin.user`                     | Login user for backups (required if ACL enabled)                      | `groot`                                             |
 | `backups.admin.password`                 | Login user password for backups (required if ACL enabled)             | `password`                                          |

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -100,7 +100,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `serviceAccount.create`                  | Create ServiceAccount                                                 | `true`                                              |
 | `serviceAccount.annotations`             | ServiceAccount annotations                                            | `{}`                                                |
 | `serviceAccount.name`                    | ServiceAccount name                                                   | `dgraph`                                            |
-| `serviceAccount.automountServiceAccountToken` | automatially mount a ServiceAccount API credentials              | `true`                                              |
+| `serviceAccount.automountServiceAccountToken` | automatically mount a ServiceAccount API credentials              | `true`                                              |
 | `zero.name`                              | Zero component name                                                   | `zero`                                              |
 | `zero.metrics.enabled`                   | Add annotations for Prometheus metric scraping                        | `true`                                              |
 | `zero.extraAnnotations`                  | Specify annotations for template metadata                             | `{}`                                                |
@@ -120,7 +120,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `zero.extraEnvs`                         | extra env vars                                                        | `[]`                                                |
 | `zero.extraFlags`                        | Zero extra flags for command line                                     | `""`                                                |
 | `zero.configFile`                        | Zero config file                                                      | `{}`                                                |
-| `zero.automountServiceAccountToken`      | automatially mount a ServiceAccount API credentials                   | `true`                                              |
+| `zero.automountServiceAccountToken`      | automatically mount a ServiceAccount API credentials                   | `true`                                              |
 | `zero.service.type`                      | Zero service type                                                     | `ClusterIP`                                         |
 | `zero.service.labels`                    | Zero service labels                                                   | `{}`                                                |
 | `zero.service.annotations`               | Zero service annotations                                              | `{}`                                                |
@@ -163,7 +163,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `alpha.extraEnvs`                        | extra env vars                                                        | `[]`                                                |
 | `alpha.extraFlags`                       | Alpha extra flags for command                                         | `""`                                                |
 | `alpha.configFile`                       | Alpha config file                                                     | `{}`                                                |
-| `alpha.automountServiceAccountToken`     | automatially mount a ServiceAccount API credentials                   | `true`                                              |
+| `alpha.automountServiceAccountToken`     | automatically mount a ServiceAccount API credentials                   | `true`                                              |
 | `alpha.service.type`                     | Alpha node service type                                               | `ClusterIP`                                         |
 | `alpha.service.labels`                   | Alpha service labels                                                  | `{}`                                                |
 | `alpha.service.annotations`              | Alpha service annotations                                             | `{}`                                                |
@@ -226,7 +226,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `ratel.envFrom`                          | Extra environment variables loaded from configmap(s) and/or secret(s) | `[]`                                                |
 | `ratel.extraEnvs`                        | Extra env vars                                                        | `[]`                                                |
 | `ratel.args`                             | Ratel command line arguments                                          | `[]`                                                |
-| `ratel.automountServiceAccountToken`     | automatially mount a ServiceAccount API credentials                   | `true`                                              |
+| `ratel.automountServiceAccountToken`     | automatically mount a ServiceAccount API credentials                   | `true`                                              |
 | `ratel.service.type`                     | Ratel service type                                                    | `ClusterIP`                                         |
 | `ratel.service.labels`                   | Ratel Service labels                                                  | `{}`                                                |
 | `ratel.service.annotations`              | Ratel Service annotations                                             | `{}`                                                |

--- a/charts/dgraph/example_values/alpha-acl-config.yaml
+++ b/charts/dgraph/example_values/alpha-acl-config.yaml
@@ -1,6 +1,6 @@
 ## alpha-acl-config.yaml
 ## Specify Access Control Lists configuration options for `dgraph alpha`
-## * https://dgraph.io/docs/enterprise-features/access-control-lists/
+## * https://dgraph.io/docs/access-control-lists/
 alpha:
   acl:
     enabled: true

--- a/charts/dgraph/example_values/alpha-acl-config.yaml
+++ b/charts/dgraph/example_values/alpha-acl-config.yaml
@@ -1,6 +1,6 @@
 ## alpha-acl-config.yaml
 ## Specify Access Control Lists configuration options for `dgraph alpha`
-## * https://dgraph.io/docs/access-control-lists/
+## * https://docs.dgraph.io/installation/configuration/enable-acl
 alpha:
   acl:
     enabled: true

--- a/charts/dgraph/example_values/alpha-acl-secrets.yaml
+++ b/charts/dgraph/example_values/alpha-acl-secrets.yaml
@@ -1,5 +1,5 @@
 ## alpha-acl-secret.yaml
-## * https://dgraph.io/docs/enterprise-features/access-control-lists/
+## * https://dgraph.io/docs/access-control-lists/
 alpha:
   acl:
     file:

--- a/charts/dgraph/example_values/alpha-acl-secrets.yaml
+++ b/charts/dgraph/example_values/alpha-acl-secrets.yaml
@@ -1,5 +1,5 @@
 ## alpha-acl-secret.yaml
-## * https://dgraph.io/docs/access-control-lists/
+## * https://docs.dgraph.io/installation/configuration/enable-acl
 alpha:
   acl:
     file:

--- a/charts/dgraph/example_values/alpha-enc-config.yaml
+++ b/charts/dgraph/example_values/alpha-enc-config.yaml
@@ -1,6 +1,6 @@
 ## alpha-enc-config.yaml
 ## Specify Encryption at Rest configuration options for `dgraph alpha`
-## * https://dgraph.io/docs/enterprise-features/encryption-at-rest/
+## * https://dgraph.io/docs/encryption-at-rest/
 alpha:
   encryption:
     enabled: true

--- a/charts/dgraph/example_values/alpha-enc-config.yaml
+++ b/charts/dgraph/example_values/alpha-enc-config.yaml
@@ -1,6 +1,6 @@
 ## alpha-enc-config.yaml
 ## Specify Encryption at Rest configuration options for `dgraph alpha`
-## * https://dgraph.io/docs/encryption-at-rest/
+## * https://docs.dgraph.io/installation/configuration/encryption-at-rest
 alpha:
   encryption:
     enabled: true

--- a/charts/dgraph/example_values/alpha-enc-secrets.yaml
+++ b/charts/dgraph/example_values/alpha-enc-secrets.yaml
@@ -1,5 +1,5 @@
 ## alpha-enc-secret.yaml
-## * https://dgraph.io/docs/enterprise-features/encryption-at-rest/
+## * https://dgraph.io/docs/encryption-at-rest/
 alpha:
   encryption:
     file:

--- a/charts/dgraph/example_values/alpha-enc-secrets.yaml
+++ b/charts/dgraph/example_values/alpha-enc-secrets.yaml
@@ -1,5 +1,5 @@
 ## alpha-enc-secret.yaml
-## * https://dgraph.io/docs/encryption-at-rest/
+## * https://docs.dgraph.io/installation/configuration/encryption-at-rest
 alpha:
   encryption:
     file:

--- a/charts/dgraph/example_values/alpha-tls-config.yaml
+++ b/charts/dgraph/example_values/alpha-tls-config.yaml
@@ -1,6 +1,6 @@
 ## alpha-tls-config.yaml
 ## Specify TLS configuration options for `dgraph alpha`
-## * https://dgraph.io/docs/deploy/security/tls-configuration/#tls-options
+## * https://docs.dgraph.io/admin/security/tls-configuration#tls-options
 ##
 ## NOTE: Client Certificates used for Mutual TLS with Dgraph Alpha do not need to
 ## be configured in this file.  These client certificates are needed by clients to

--- a/charts/dgraph/example_values/alpha-tls-secrets.yaml
+++ b/charts/dgraph/example_values/alpha-tls-secrets.yaml
@@ -1,6 +1,6 @@
 ## alpha-tls-secrets.yaml
 ## Generate keys/certs with `dgraph cert`
-## * https://dgraph.io/docs/deploy/security/tls-configuration/#tls-options
+## * https://docs.dgraph.io/admin/security/tls-configuration#tls-options
 ##
 ## Create Dgraph certs/keys for Kubernetes with:
 ##  MYLIST=$(REPLICAS=3 RELEASE=my-release NAMESPACE=default ../scripts/get_alpha_list.sh)

--- a/charts/dgraph/example_values/backup-minio-config.yaml
+++ b/charts/dgraph/example_values/backup-minio-config.yaml
@@ -1,9 +1,9 @@
 ## backup-minio-config.yaml
-## * https://dgraph.io/docs/enterprise-features/binary-backups/
+## * https://dgraph.io/docs/binary-backups/
 ##
 ## Demonstrates
 ## * Binary Backups to Minio
-## * ACL feature with Alice user (see https://dgraph.io/docs/enterprise-features/access-control-lists/)
+## * ACL feature with Alice user (see https://dgraph.io/docs/access-control-lists/)
 backups:
   full:
     enabled: true

--- a/charts/dgraph/example_values/backup-minio-config.yaml
+++ b/charts/dgraph/example_values/backup-minio-config.yaml
@@ -1,9 +1,9 @@
 ## backup-minio-config.yaml
-## * https://dgraph.io/docs/binary-backups/
+## * https://docs.dgraph.io/admin/admin-tasks/binary-backups
 ##
 ## Demonstrates
 ## * Binary Backups to Minio
-## * ACL feature with Alice user (see https://dgraph.io/docs/access-control-lists/)
+## * ACL feature with Alice user (see https://docs.dgraph.io/installation/configuration/enable-acl)
 backups:
   full:
     enabled: true

--- a/charts/dgraph/example_values/backup-minio-secrets.yaml
+++ b/charts/dgraph/example_values/backup-minio-secrets.yaml
@@ -1,5 +1,5 @@
 ## backup-minio-config.yaml
-## * https://dgraph.io/docs/binary-backups/
+## * https://docs.dgraph.io/admin/admin-tasks/binary-backups
 backups:
   admin:
     password: whiterabbit

--- a/charts/dgraph/example_values/backup-minio-secrets.yaml
+++ b/charts/dgraph/example_values/backup-minio-secrets.yaml
@@ -1,5 +1,5 @@
 ## backup-minio-config.yaml
-## * https://dgraph.io/docs/enterprise-features/binary-backups/
+## * https://dgraph.io/docs/binary-backups/
 backups:
   admin:
     password: whiterabbit

--- a/charts/dgraph/example_values/backup-nfs-config.yaml
+++ b/charts/dgraph/example_values/backup-nfs-config.yaml
@@ -1,5 +1,5 @@
 ## backup-nfs-config.yaml
-## * https://dgraph.io/docs/binary-backups/
+## * https://docs.dgraph.io/admin/admin-tasks/binary-backups
 ##
 ## Demonstrates binary backups to NFS Server
 ## Note that NFS server must be configured previously and firewall rules to allow

--- a/charts/dgraph/example_values/backup-nfs-config.yaml
+++ b/charts/dgraph/example_values/backup-nfs-config.yaml
@@ -1,5 +1,5 @@
 ## backup-nfs-config.yaml
-## * https://dgraph.io/docs/enterprise-features/binary-backups/
+## * https://dgraph.io/docs/binary-backups/
 ##
 ## Demonstrates binary backups to NFS Server
 ## Note that NFS server must be configured previously and firewall rules to allow

--- a/charts/dgraph/example_values/backup-s3-config.yaml
+++ b/charts/dgraph/example_values/backup-s3-config.yaml
@@ -3,8 +3,8 @@
 ##
 ## Demonstrates
 ## * Binary Backups to S3
-## * Mutual TLS (see https://dgraph.io/docs/deploy/security/tls-configuration/#tls-options)
-## * Auth Token (see https://dgraph.io/docs/deploy/admin/dgraph-administration/#secure-alter-operations)
+## * Mutual TLS (see https://docs.dgraph.io/admin/security/tls-configuration#tls-options)
+## * Auth Token (see https://docs.dgraph.io/admin/security/admin-endpoint-security#securing-alter-operations)
 backups:
   full:
     enabled: true

--- a/charts/dgraph/example_values/backup-s3-config.yaml
+++ b/charts/dgraph/example_values/backup-s3-config.yaml
@@ -1,5 +1,5 @@
 ## backup-s3-config.yaml
-## * https://dgraph.io/docs/enterprise-features/binary-backups/
+## * https://dgraph.io/docs/binary-backups/
 ##
 ## Demonstrates
 ## * Binary Backups to S3

--- a/charts/dgraph/example_values/backup-s3-config.yaml
+++ b/charts/dgraph/example_values/backup-s3-config.yaml
@@ -1,5 +1,5 @@
 ## backup-s3-config.yaml
-## * https://dgraph.io/docs/binary-backups/
+## * https://docs.dgraph.io/admin/admin-tasks/binary-backups
 ##
 ## Demonstrates
 ## * Binary Backups to S3

--- a/charts/dgraph/example_values/backup-s3-secrets.yaml
+++ b/charts/dgraph/example_values/backup-s3-secrets.yaml
@@ -1,5 +1,5 @@
 ## backup-minio-config.yaml
-## * https://dgraph.io/docs/binary-backups/
+## * https://docs.dgraph.io/admin/admin-tasks/binary-backups
 alpha:
   tls:
     files:

--- a/charts/dgraph/example_values/backup-s3-secrets.yaml
+++ b/charts/dgraph/example_values/backup-s3-secrets.yaml
@@ -1,5 +1,5 @@
 ## backup-minio-config.yaml
-## * https://dgraph.io/docs/enterprise-features/binary-backups/
+## * https://dgraph.io/docs/binary-backups/
 alpha:
   tls:
     files:

--- a/charts/dgraph/example_values/backup-volume-config.yaml
+++ b/charts/dgraph/example_values/backup-volume-config.yaml
@@ -1,5 +1,5 @@
 ## backup-volume-config.yaml
-## * https://dgraph.io/docs/enterprise-features/binary-backups/
+## * https://dgraph.io/docs/binary-backups/
 ##
 ## Demonstrates binary backups with custom PVC + PV
 ## Note that the PV and PVC must have been previously created before installing

--- a/charts/dgraph/example_values/backup-volume-config.yaml
+++ b/charts/dgraph/example_values/backup-volume-config.yaml
@@ -1,5 +1,5 @@
 ## backup-volume-config.yaml
-## * https://dgraph.io/docs/binary-backups/
+## * https://docs.dgraph.io/admin/admin-tasks/binary-backups
 ##
 ## Demonstrates binary backups with custom PVC + PV
 ## Note that the PV and PVC must have been previously created before installing

--- a/charts/dgraph/example_values/zero-tls-config.yaml
+++ b/charts/dgraph/example_values/zero-tls-config.yaml
@@ -1,5 +1,5 @@
 ## Specify TLS configuration options for `dgraph alpha` and `dgraph zero`
-## * https://dgraph.io/docs/deploy/security/tls-configuration/#using-tls-with-internal-and-external-ports-encrypted
+## * https://docs.dgraph.io/admin/security/tls-configuration#using-tls-with-internal-and-external-ports-encrypted
 ## NOTE: Client Certificates used for Mutual TLS must be configured, as these are
 ## need by Dgraph nodes to authenticate to each other.
 global:

--- a/charts/dgraph/example_values/zero-tls-secrets.yaml
+++ b/charts/dgraph/example_values/zero-tls-secrets.yaml
@@ -1,5 +1,5 @@
 ## Specify TLS configuration options for `dgraph alpha` and `dgraph zero`
-## * https://dgraph.io/docs/deploy/security/tls-configuration/#using-tls-with-internal-and-external-ports-encrypted
+## * https://docs.dgraph.io/admin/security/tls-configuration#using-tls-with-internal-and-external-ports-encrypted
 ## NOTE: Client Certificates used for Mutual TLS must be included, as these are
 ## need by Dgraph nodes to authenticate to each other.
 alpha:

--- a/charts/dgraph/scripts/README.md
+++ b/charts/dgraph/scripts/README.md
@@ -4,7 +4,7 @@ Here are some scripts that may be useful for generating helm chart values for us
 
 ## make_tls_secrets.sh
 
-For intructions run `./make_tls_secrets.sh --help`
+For instructions run `./make_tls_secrets.sh --help`
 
 As an example:
 

--- a/charts/dgraph/scripts/make_tls_secrets.sh
+++ b/charts/dgraph/scripts/make_tls_secrets.sh
@@ -40,7 +40,7 @@ USAGE
 check_environment() {
   ## Check for dgraph command
   command -v dgraph > /dev/null || \
-    { echo "[ERROR]: 'dgraph' command not not found" 1>&2; exit 1; }
+    { echo "[ERROR]: 'dgraph' command not found" 1>&2; exit 1; }
 }
 
 ######

--- a/charts/dgraph/templates/NOTES.txt
+++ b/charts/dgraph/templates/NOTES.txt
@@ -1,7 +1,7 @@
 1. You have just deployed Dgraph, version '{{ .Values.image.tag }}'.
 
    For further information:
-     * Documentation: https://dgraph.io/docs/
+     * Documentation: https://docs.dgraph.io/
      * Community and Issues: https://discuss.dgraph.io/
    {{ if or (eq .Values.image.tag "latest") (eq .Values.image.tag "master") }}
    NOTE: Using 'latest' or 'master' for 'image.tag' is DANGEROUS and can lead to data loss.

--- a/charts/dgraph/templates/NOTES.txt
+++ b/charts/dgraph/templates/NOTES.txt
@@ -68,7 +68,7 @@
 
     export RATEL_POD_NAME=$(kubectl get pods --namespace {{ include "dgraph.namespace" . }} --selector "component={{ .Values.ratel.name }},release={{ .Release.Name }}" --output jsonpath="{.items[0].metadata.name}")
     echo "Access Ratel HTTP/S using http://localhost:8000"
-    kubectl --namespace {{ include "dgraph.namespace" . }} port-forward $POD_NARATEL_POD_NAMEME 8000:8000
+    kubectl --namespace {{ include "dgraph.namespace" . }} port-forward $RATEL_POD_NAME 8000:8000
 
 {{- end }}
 

--- a/charts/dgraph/templates/_helpers.tpl
+++ b/charts/dgraph/templates/_helpers.tpl
@@ -206,8 +206,15 @@ are always sorted alphabetically by Go's YAML marshaler.
 Parameters (passed as a dict):
   ctx        — the Helm root context (required)
   component  — value for component / app.kubernetes.io/component (optional)
-  extra      — dict of additional labels, e.g. monitor or cronjob (optional)
+  extra      — dict of additional chart-defined labels, e.g. monitor or cronjob (optional)
   podLabels  — dict of user-supplied per-component pod labels (optional)
+
+Precedence (first wins on key conflicts):
+  standard labels > component > extra > podLabels > commonLabels
+
+Note: extra labels (like monitor) cannot be overridden by podLabels or
+commonLabels. This is intentional — chart-defined labels take priority
+over user-supplied ones.
 */}}
 {{- define "dgraph.labels" -}}
 {{- $ctx := .ctx -}}

--- a/charts/dgraph/templates/_helpers.tpl
+++ b/charts/dgraph/templates/_helpers.tpl
@@ -200,6 +200,24 @@ Create a default fully qualified ratel name.
 {{- end -}}
 
 {{/*
+Common labels shared by all resources. Includes both legacy Helm labels and
+Kubernetes recommended labels (excluding component, which varies per resource).
+*/}}
+{{- define "dgraph.standardLabels" -}}
+app: {{ include "dgraph.name" . }}
+chart: {{ include "dgraph.chart" . }}
+release: {{ .Release.Name }}
+heritage: {{ .Release.Service }}
+helm.sh/chart: {{ include "dgraph.chart" . }}
+app.kubernetes.io/name: {{ include "dgraph.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
 Allow overriding namespace
 */}}
 {{- define "dgraph.namespace" -}}

--- a/charts/dgraph/templates/_helpers.tpl
+++ b/charts/dgraph/templates/_helpers.tpl
@@ -200,25 +200,41 @@ Create a default fully qualified ratel name.
 {{- end -}}
 
 {{/*
-Common labels shared by all resources. Includes both legacy Helm labels and
-Kubernetes recommended labels (excluding component, which varies per resource).
+Build a complete label set as a dict and render via toYaml so that keys
+are always sorted alphabetically by Go's YAML marshaler.
+
+Parameters (passed as a dict):
+  ctx        — the Helm root context (required)
+  component  — value for component / app.kubernetes.io/component (optional)
+  extra      — dict of additional labels, e.g. monitor or cronjob (optional)
+  podLabels  — dict of user-supplied per-component pod labels (optional)
 */}}
-{{- define "dgraph.standardLabels" -}}
-app: {{ include "dgraph.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/name: {{ include "dgraph.name" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-chart: {{ include "dgraph.chart" . }}
-helm.sh/chart: {{ include "dgraph.chart" . }}
-heritage: {{ .Release.Service }}
-release: {{ .Release.Name }}
-{{- with .Values.commonLabels }}
-{{ toYaml . }}
-{{- end }}
-{{- end }}
+{{- define "dgraph.labels" -}}
+{{- $ctx := .ctx -}}
+{{- $labels := dict
+  "app" (include "dgraph.name" $ctx)
+  "app.kubernetes.io/instance" $ctx.Release.Name
+  "app.kubernetes.io/managed-by" $ctx.Release.Service
+  "app.kubernetes.io/name" (include "dgraph.name" $ctx)
+  "chart" (include "dgraph.chart" $ctx)
+  "helm.sh/chart" (include "dgraph.chart" $ctx)
+  "heritage" $ctx.Release.Service
+  "release" $ctx.Release.Name
+-}}
+{{- if $ctx.Chart.AppVersion -}}
+{{- $_ := set $labels "app.kubernetes.io/version" $ctx.Chart.AppVersion -}}
+{{- end -}}
+{{- if .component -}}
+{{- $_ := set $labels "app.kubernetes.io/component" .component -}}
+{{- $_ := set $labels "component" .component -}}
+{{- end -}}
+{{- range $key, $val := (default (dict) .extra) -}}
+{{- $_ := set $labels $key $val -}}
+{{- end -}}
+{{- $labels = merge $labels (default (dict) .podLabels) -}}
+{{- $labels = merge $labels (default (dict) $ctx.Values.commonLabels) -}}
+{{- toYaml $labels -}}
+{{- end -}}
 
 {{/*
 Allow overriding namespace

--- a/charts/dgraph/templates/_helpers.tpl
+++ b/charts/dgraph/templates/_helpers.tpl
@@ -236,7 +236,7 @@ show their chart-defined monitorLabel value instead.
 {{- define "dgraph.labels" -}}
 {{- $ctx := .ctx -}}
 {{- $labels := default (dict) $ctx.Values.commonLabels | deepCopy -}}
-{{- $labels = merge (default (dict) .podLabels) $labels -}}
+{{- $labels = merge (default (dict) .podLabels | deepCopy) $labels -}}
 {{- range $key, $val := (default (dict) .extra) -}}
 {{- $_ := set $labels $key $val -}}
 {{- end -}}

--- a/charts/dgraph/templates/_helpers.tpl
+++ b/charts/dgraph/templates/_helpers.tpl
@@ -215,6 +215,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/dgraph/templates/_helpers.tpl
+++ b/charts/dgraph/templates/_helpers.tpl
@@ -209,11 +209,29 @@ Parameters (passed as a dict):
   extra      — dict of additional chart-defined labels, e.g. monitor or cronjob (optional)
   podLabels  — dict of user-supplied per-component pod labels (optional)
 
-Precedence (last applied wins on key conflicts):
-  commonLabels < podLabels < extra < component < standard labels
+On key conflicts, higher-priority sources override lower-priority ones:
+  (lowest)  commonLabels  — from values.yaml, applied to every resource
+            podLabels     — from values.yaml, only passed on pod templates
+            extra         — chart-defined, only passed by specific templates
+            component     — chart-defined, omitted on shared resources like the ServiceAccount
+  (highest) standard labels (app, chart, release, heritage, app.kubernetes.io/*)
 
-User-supplied commonLabels have the lowest priority and cannot override
-any chart-defined or per-component label.
+For example, commonLabels cannot override standard labels like "app" or
+"release", and podLabels cannot override chart-defined extra labels.
+
+Not every call passes every parameter. The "extra" parameter is only
+used by templates that need additional chart-defined labels:
+  - alpha/zero non-headless Services pass extra.monitor (from monitorLabel)
+  - alpha/zero headless Services pass extra from serviceHeadless.labels
+  - ratel Service passes extra from service.labels
+  - backup CronJob pod templates pass extra.cronjob
+The "component" parameter is omitted on the shared ServiceAccount and
+the pre-upgrade hook resources (which aren't component-specific).
+
+Note on monitorLabel: because "monitor" is only passed as an extra on
+the two non-headless Services, setting commonLabels.monitor will add a
+"monitor" label to most resources, but those two Services will still
+show their chart-defined monitorLabel value instead.
 */}}
 {{- define "dgraph.labels" -}}
 {{- $ctx := .ctx -}}

--- a/charts/dgraph/templates/_helpers.tpl
+++ b/charts/dgraph/templates/_helpers.tpl
@@ -236,7 +236,7 @@ show their chart-defined monitorLabel value instead.
 {{- define "dgraph.labels" -}}
 {{- $ctx := .ctx -}}
 {{- $labels := default (dict) $ctx.Values.commonLabels | deepCopy -}}
-{{- $labels = merge (default (dict) .podLabels | deepCopy) $labels -}}
+{{- $_ := deepCopy (default (dict) .podLabels) | mergeOverwrite $labels -}}
 {{- range $key, $val := (default (dict) .extra) -}}
 {{- $_ := set $labels $key $val -}}
 {{- end -}}

--- a/charts/dgraph/templates/_helpers.tpl
+++ b/charts/dgraph/templates/_helpers.tpl
@@ -209,37 +209,34 @@ Parameters (passed as a dict):
   extra      — dict of additional chart-defined labels, e.g. monitor or cronjob (optional)
   podLabels  — dict of user-supplied per-component pod labels (optional)
 
-Precedence (first wins on key conflicts):
-  standard labels > component > extra > podLabels > commonLabels
+Precedence (last applied wins on key conflicts):
+  commonLabels < podLabels < extra < component < standard labels
 
-Note: extra labels (like monitor) cannot be overridden by podLabels or
-commonLabels. This is intentional — chart-defined labels take priority
-over user-supplied ones.
+User-supplied commonLabels have the lowest priority and cannot override
+any chart-defined or per-component label.
 */}}
 {{- define "dgraph.labels" -}}
 {{- $ctx := .ctx -}}
-{{- $labels := dict
-  "app" (include "dgraph.name" $ctx)
-  "app.kubernetes.io/instance" $ctx.Release.Name
-  "app.kubernetes.io/managed-by" $ctx.Release.Service
-  "app.kubernetes.io/name" (include "dgraph.name" $ctx)
-  "chart" (include "dgraph.chart" $ctx)
-  "helm.sh/chart" (include "dgraph.chart" $ctx)
-  "heritage" $ctx.Release.Service
-  "release" $ctx.Release.Name
--}}
-{{- if $ctx.Chart.AppVersion -}}
-{{- $_ := set $labels "app.kubernetes.io/version" $ctx.Chart.AppVersion -}}
+{{- $labels := default (dict) $ctx.Values.commonLabels | deepCopy -}}
+{{- $labels = merge (default (dict) .podLabels) $labels -}}
+{{- range $key, $val := (default (dict) .extra) -}}
+{{- $_ := set $labels $key $val -}}
 {{- end -}}
 {{- if .component -}}
 {{- $_ := set $labels "app.kubernetes.io/component" .component -}}
 {{- $_ := set $labels "component" .component -}}
 {{- end -}}
-{{- range $key, $val := (default (dict) .extra) -}}
-{{- $_ := set $labels $key $val -}}
+{{- $_ := set $labels "app" (include "dgraph.name" $ctx) -}}
+{{- $_ := set $labels "app.kubernetes.io/instance" $ctx.Release.Name -}}
+{{- $_ := set $labels "app.kubernetes.io/managed-by" $ctx.Release.Service -}}
+{{- $_ := set $labels "app.kubernetes.io/name" (include "dgraph.name" $ctx) -}}
+{{- if $ctx.Chart.AppVersion -}}
+{{- $_ := set $labels "app.kubernetes.io/version" $ctx.Chart.AppVersion -}}
 {{- end -}}
-{{- $labels = merge $labels (default (dict) .podLabels) -}}
-{{- $labels = merge $labels (default (dict) $ctx.Values.commonLabels) -}}
+{{- $_ := set $labels "chart" (include "dgraph.chart" $ctx) -}}
+{{- $_ := set $labels "helm.sh/chart" (include "dgraph.chart" $ctx) -}}
+{{- $_ := set $labels "heritage" $ctx.Release.Service -}}
+{{- $_ := set $labels "release" $ctx.Release.Name -}}
 {{- toYaml $labels -}}
 {{- end -}}
 

--- a/charts/dgraph/templates/_helpers.tpl
+++ b/charts/dgraph/templates/_helpers.tpl
@@ -205,16 +205,16 @@ Kubernetes recommended labels (excluding component, which varies per resource).
 */}}
 {{- define "dgraph.standardLabels" -}}
 app: {{ include "dgraph.name" . }}
-chart: {{ include "dgraph.chart" . }}
-release: {{ .Release.Name }}
-heritage: {{ .Release.Service }}
-helm.sh/chart: {{ include "dgraph.chart" . }}
-app.kubernetes.io/name: {{ include "dgraph.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/name: {{ include "dgraph.name" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
+chart: {{ include "dgraph.chart" . }}
+helm.sh/chart: {{ include "dgraph.chart" . }}
+heritage: {{ .Release.Service }}
+release: {{ .Release.Name }}
 {{- with .Values.commonLabels }}
 {{ toYaml . }}
 {{- end }}

--- a/charts/dgraph/templates/alpha/configs.yaml
+++ b/charts/dgraph/templates/alpha/configs.yaml
@@ -8,10 +8,6 @@ metadata:
     app.kubernetes.io/component: {{ .Values.alpha.name }}
     component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- with .Values.commonAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 data:
   {{- with .Values.alpha.configFile }}
     {{- toYaml . | trimSuffix "\n" | nindent 2 }}

--- a/charts/dgraph/templates/alpha/configs.yaml
+++ b/charts/dgraph/templates/alpha/configs.yaml
@@ -8,6 +8,10 @@ metadata:
     component: {{ .Values.alpha.name }}
     app.kubernetes.io/component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   {{- with .Values.alpha.configFile }}
     {{- toYaml . | trimSuffix "\n" | nindent 2 }}

--- a/charts/dgraph/templates/alpha/configs.yaml
+++ b/charts/dgraph/templates/alpha/configs.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-config
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    component: {{ .Values.alpha.name }}
     app.kubernetes.io/component: {{ .Values.alpha.name }}
+    component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- with .Values.commonAnnotations }}
   annotations:

--- a/charts/dgraph/templates/alpha/configs.yaml
+++ b/charts/dgraph/templates/alpha/configs.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-config
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.alpha.name }}
-    component: {{ .Values.alpha.name }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.alpha.name) | nindent 4 }}
 data:
   {{- with .Values.alpha.configFile }}
     {{- toYaml . | trimSuffix "\n" | nindent 2 }}

--- a/charts/dgraph/templates/alpha/configs.yaml
+++ b/charts/dgraph/templates/alpha/configs.yaml
@@ -5,11 +5,9 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-config
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.alpha.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ .Values.alpha.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
 data:
   {{- with .Values.alpha.configFile }}
     {{- toYaml . | trimSuffix "\n" | nindent 2 }}

--- a/charts/dgraph/templates/alpha/ingress.yaml
+++ b/charts/dgraph/templates/alpha/ingress.yaml
@@ -24,9 +24,7 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-ingress
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.alpha.name }}
-    component: {{ .Values.alpha.name }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.alpha.name) | nindent 4 }}
   {{- with .Values.alpha.ingress.annotations }}
   annotations:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
@@ -68,9 +66,7 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-ingress-grpc
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.alpha.name }}
-    component: {{ .Values.alpha.name }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.alpha.name) | nindent 4 }}
   {{- with .Values.alpha.ingress_grpc.annotations }}
   annotations:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}

--- a/charts/dgraph/templates/alpha/ingress.yaml
+++ b/charts/dgraph/templates/alpha/ingress.yaml
@@ -27,14 +27,9 @@ metadata:
     app.kubernetes.io/component: {{ .Values.alpha.name }}
     component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- if or .Values.alpha.ingress.annotations .Values.commonAnnotations }}
+  {{- with .Values.alpha.ingress.annotations }}
   annotations:
-    {{- with .Values.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- with .Values.alpha.ingress.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
-    {{- end }}
   {{- end }}
 spec:
 {{- if .Values.alpha.ingress.ingressClassName }}
@@ -76,14 +71,9 @@ metadata:
     app.kubernetes.io/component: {{ .Values.alpha.name }}
     component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- if or .Values.alpha.ingress_grpc.annotations .Values.commonAnnotations }}
+  {{- with .Values.alpha.ingress_grpc.annotations }}
   annotations:
-    {{- with .Values.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- with .Values.alpha.ingress_grpc.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
-    {{- end }}
   {{- end }}
 spec:
 {{- if .Values.alpha.ingress_grpc.ingressClassName }}

--- a/charts/dgraph/templates/alpha/ingress.yaml
+++ b/charts/dgraph/templates/alpha/ingress.yaml
@@ -24,11 +24,9 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-ingress
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.alpha.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ .Values.alpha.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- with .Values.alpha.ingress.annotations }}
   annotations:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
@@ -70,11 +68,9 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-ingress-grpc
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.alpha.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ .Values.alpha.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- with .Values.alpha.ingress_grpc.annotations }}
   annotations:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}

--- a/charts/dgraph/templates/alpha/ingress.yaml
+++ b/charts/dgraph/templates/alpha/ingress.yaml
@@ -24,8 +24,8 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-ingress
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    component: {{ .Values.alpha.name }}
     app.kubernetes.io/component: {{ .Values.alpha.name }}
+    component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- if or .Values.alpha.ingress.annotations .Values.commonAnnotations }}
   annotations:
@@ -73,8 +73,8 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-ingress-grpc
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    component: {{ .Values.alpha.name }}
     app.kubernetes.io/component: {{ .Values.alpha.name }}
+    component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- if or .Values.alpha.ingress_grpc.annotations .Values.commonAnnotations }}
   annotations:

--- a/charts/dgraph/templates/alpha/ingress.yaml
+++ b/charts/dgraph/templates/alpha/ingress.yaml
@@ -27,9 +27,14 @@ metadata:
     component: {{ .Values.alpha.name }}
     app.kubernetes.io/component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- with .Values.alpha.ingress.annotations }}
+  {{- if or .Values.alpha.ingress.annotations .Values.commonAnnotations }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.alpha.ingress.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
 {{- if .Values.alpha.ingress.ingressClassName }}
@@ -71,9 +76,14 @@ metadata:
     component: {{ .Values.alpha.name }}
     app.kubernetes.io/component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- with .Values.alpha.ingress_grpc.annotations }}
+  {{- if or .Values.alpha.ingress_grpc.annotations .Values.commonAnnotations }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.alpha.ingress_grpc.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
 {{- if .Values.alpha.ingress_grpc.ingressClassName }}

--- a/charts/dgraph/templates/alpha/secret-acl.yaml
+++ b/charts/dgraph/templates/alpha/secret-acl.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-acl-secret
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    component: {{ .Values.alpha.name }}
     app.kubernetes.io/component: {{ .Values.alpha.name }}
+    component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- if or .Values.alpha.tls.annotations .Values.commonAnnotations }}
   annotations:

--- a/charts/dgraph/templates/alpha/secret-acl.yaml
+++ b/charts/dgraph/templates/alpha/secret-acl.yaml
@@ -5,11 +5,9 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-acl-secret
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.alpha.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ .Values.alpha.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- with .Values.alpha.tls.annotations }}
   annotations:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}

--- a/charts/dgraph/templates/alpha/secret-acl.yaml
+++ b/charts/dgraph/templates/alpha/secret-acl.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-acl-secret
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.alpha.name }}
-    component: {{ .Values.alpha.name }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.alpha.name) | nindent 4 }}
   {{- with .Values.alpha.tls.annotations }}
   annotations:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}

--- a/charts/dgraph/templates/alpha/secret-acl.yaml
+++ b/charts/dgraph/templates/alpha/secret-acl.yaml
@@ -8,9 +8,14 @@ metadata:
     component: {{ .Values.alpha.name }}
     app.kubernetes.io/component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- with .Values.alpha.tls.annotations }}
+  {{- if or .Values.alpha.tls.annotations .Values.commonAnnotations }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.alpha.tls.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
+    {{- end }}
   {{- end }}
 type: Opaque
 data:

--- a/charts/dgraph/templates/alpha/secret-acl.yaml
+++ b/charts/dgraph/templates/alpha/secret-acl.yaml
@@ -8,14 +8,9 @@ metadata:
     app.kubernetes.io/component: {{ .Values.alpha.name }}
     component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- if or .Values.alpha.tls.annotations .Values.commonAnnotations }}
+  {{- with .Values.alpha.tls.annotations }}
   annotations:
-    {{- with .Values.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- with .Values.alpha.tls.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
-    {{- end }}
   {{- end }}
 type: Opaque
 data:

--- a/charts/dgraph/templates/alpha/secret-enc.yaml
+++ b/charts/dgraph/templates/alpha/secret-enc.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-encryption-secret
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    component: {{ .Values.alpha.name }}
     app.kubernetes.io/component: {{ .Values.alpha.name }}
+    component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- if or .Values.alpha.tls.annotations .Values.commonAnnotations }}
   annotations:

--- a/charts/dgraph/templates/alpha/secret-enc.yaml
+++ b/charts/dgraph/templates/alpha/secret-enc.yaml
@@ -8,9 +8,14 @@ metadata:
     component: {{ .Values.alpha.name }}
     app.kubernetes.io/component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- with .Values.alpha.tls.annotations }}
+  {{- if or .Values.alpha.tls.annotations .Values.commonAnnotations }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.alpha.tls.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
+    {{- end }}
   {{- end }}
 type: Opaque
 data:

--- a/charts/dgraph/templates/alpha/secret-enc.yaml
+++ b/charts/dgraph/templates/alpha/secret-enc.yaml
@@ -5,11 +5,9 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-encryption-secret
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.alpha.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ .Values.alpha.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- with .Values.alpha.tls.annotations }}
   annotations:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}

--- a/charts/dgraph/templates/alpha/secret-enc.yaml
+++ b/charts/dgraph/templates/alpha/secret-enc.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-encryption-secret
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.alpha.name }}
-    component: {{ .Values.alpha.name }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.alpha.name) | nindent 4 }}
   {{- with .Values.alpha.tls.annotations }}
   annotations:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}

--- a/charts/dgraph/templates/alpha/secret-enc.yaml
+++ b/charts/dgraph/templates/alpha/secret-enc.yaml
@@ -8,14 +8,9 @@ metadata:
     app.kubernetes.io/component: {{ .Values.alpha.name }}
     component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- if or .Values.alpha.tls.annotations .Values.commonAnnotations }}
+  {{- with .Values.alpha.tls.annotations }}
   annotations:
-    {{- with .Values.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- with .Values.alpha.tls.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
-    {{- end }}
   {{- end }}
 type: Opaque
 data:

--- a/charts/dgraph/templates/alpha/secret-tls.yaml
+++ b/charts/dgraph/templates/alpha/secret-tls.yaml
@@ -5,11 +5,9 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-tls-secret
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.alpha.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ .Values.alpha.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- with .Values.alpha.tls.annotations }}
   annotations:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}

--- a/charts/dgraph/templates/alpha/secret-tls.yaml
+++ b/charts/dgraph/templates/alpha/secret-tls.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-tls-secret
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.alpha.name }}
-    component: {{ .Values.alpha.name }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.alpha.name) | nindent 4 }}
   {{- with .Values.alpha.tls.annotations }}
   annotations:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}

--- a/charts/dgraph/templates/alpha/secret-tls.yaml
+++ b/charts/dgraph/templates/alpha/secret-tls.yaml
@@ -8,9 +8,14 @@ metadata:
     component: {{ .Values.alpha.name }}
     app.kubernetes.io/component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- with .Values.alpha.tls.annotations }}
+  {{- if or .Values.alpha.tls.annotations .Values.commonAnnotations }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.alpha.tls.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
+    {{- end }}
   {{- end }}
 type: Opaque
 data:

--- a/charts/dgraph/templates/alpha/secret-tls.yaml
+++ b/charts/dgraph/templates/alpha/secret-tls.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-tls-secret
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    component: {{ .Values.alpha.name }}
     app.kubernetes.io/component: {{ .Values.alpha.name }}
+    component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- if or .Values.alpha.tls.annotations .Values.commonAnnotations }}
   annotations:

--- a/charts/dgraph/templates/alpha/secret-tls.yaml
+++ b/charts/dgraph/templates/alpha/secret-tls.yaml
@@ -8,14 +8,9 @@ metadata:
     app.kubernetes.io/component: {{ .Values.alpha.name }}
     component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- if or .Values.alpha.tls.annotations .Values.commonAnnotations }}
+  {{- with .Values.alpha.tls.annotations }}
   annotations:
-    {{- with .Values.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- with .Values.alpha.tls.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
-    {{- end }}
   {{- end }}
 type: Opaque
 data:

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -4,7 +4,7 @@
   {{- $max := int .Values.zero.replicaCount -}}
   {{- $safeVersion := include "dgraph.version" . -}}
   {{- /* Reset $max to 1 if multiple zeros not supported by dgraph version */}}
-  {{- if semverCompare "< 1.2.3 || 20.03.0" $safeVersion -}}
+  {{- if or (semverCompare "< 1.2.3" $safeVersion) (semverCompare "= 20.03.0" $safeVersion) -}}
      {{- $max = 1 -}}
   {{- end -}}
 
@@ -324,7 +324,6 @@ spec:
         secret:
           secretName: {{ template "dgraph.alpha.fullname" . }}-acl-secret
       {{- end }}
-
 {{- if .Values.alpha.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -35,6 +35,10 @@ metadata:
     component: {{ .Values.alpha.name }}
     app.kubernetes.io/component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   serviceName: {{ template "dgraph.alpha.fullname" . }}-headless
   replicas: {{ .Values.alpha.replicaCount }}
@@ -55,8 +59,11 @@ spec:
   template:
     metadata:
       name: {{ template "dgraph.alpha.fullname" . }}
-      {{- if or .Values.alpha.metrics.enabled .Values.alpha.extraAnnotations }}
+      {{- if or .Values.alpha.metrics.enabled .Values.alpha.extraAnnotations .Values.commonAnnotations }}
       annotations:
+        {{- with .Values.commonAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- if .Values.alpha.metrics.enabled }}
         prometheus.io/path: /debug/prometheus_metrics
         prometheus.io/port: "8080"

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -32,11 +32,9 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.alpha.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ .Values.alpha.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
 spec:
   serviceName: {{ template "dgraph.alpha.fullname" . }}-headless
   replicas: {{ .Values.alpha.replicaCount }}
@@ -69,10 +67,9 @@ spec:
         {{- end }}
       {{- end }}
       labels:
-        app: {{ template "dgraph.name" . }}
-        chart: {{ template "dgraph.chart" . }}
-        release: {{ .Release.Name }}
         component: {{ .Values.alpha.name }}
+        app.kubernetes.io/component: {{ .Values.alpha.name }}
+        {{- include "dgraph.standardLabels" . | nindent 8 }}
         {{- if .Values.alpha.podLabels }}
 {{ .Values.alpha.podLabels | toYaml | indent 8}}
         {{- end }}

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -77,9 +77,6 @@ spec:
         component: {{ .Values.alpha.name }}
         app.kubernetes.io/component: {{ .Values.alpha.name }}
         {{- include "dgraph.standardLabels" . | nindent 8 }}
-        {{- with .Values.statefulSetPodLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
         {{- if .Values.alpha.podLabels }}
 {{ .Values.alpha.podLabels | toYaml | indent 8}}
         {{- end }}

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -35,10 +35,6 @@ metadata:
     app.kubernetes.io/component: {{ .Values.alpha.name }}
     component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- with .Values.commonAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 spec:
   serviceName: {{ template "dgraph.alpha.fullname" . }}-headless
   replicas: {{ .Values.alpha.replicaCount }}
@@ -59,11 +55,8 @@ spec:
   template:
     metadata:
       name: {{ template "dgraph.alpha.fullname" . }}
-      {{- if or .Values.alpha.metrics.enabled .Values.alpha.extraAnnotations .Values.commonAnnotations }}
+      {{- if or .Values.alpha.metrics.enabled .Values.alpha.extraAnnotations }}
       annotations:
-        {{- with .Values.commonAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
         {{- if .Values.alpha.metrics.enabled }}
         prometheus.io/path: /debug/prometheus_metrics
         prometheus.io/port: "8080"

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -32,9 +32,7 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.alpha.name }}
-    component: {{ .Values.alpha.name }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.alpha.name) | nindent 4 }}
 spec:
   serviceName: {{ template "dgraph.alpha.fullname" . }}-headless
   replicas: {{ .Values.alpha.replicaCount }}
@@ -67,12 +65,7 @@ spec:
         {{- end }}
       {{- end }}
       labels:
-        app.kubernetes.io/component: {{ .Values.alpha.name }}
-        component: {{ .Values.alpha.name }}
-        {{- include "dgraph.standardLabels" . | nindent 8 }}
-        {{- with .Values.alpha.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "dgraph.labels" (dict "ctx" . "component" .Values.alpha.name "podLabels" .Values.alpha.podLabels) | nindent 8 }}
     spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -77,6 +77,9 @@ spec:
         component: {{ .Values.alpha.name }}
         app.kubernetes.io/component: {{ .Values.alpha.name }}
         {{- include "dgraph.standardLabels" . | nindent 8 }}
+        {{- with .Values.statefulSetPodLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- if .Values.alpha.podLabels }}
 {{ .Values.alpha.podLabels | toYaml | indent 8}}
         {{- end }}

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -32,8 +32,8 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    component: {{ .Values.alpha.name }}
     app.kubernetes.io/component: {{ .Values.alpha.name }}
+    component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- with .Values.commonAnnotations }}
   annotations:
@@ -74,8 +74,8 @@ spec:
         {{- end }}
       {{- end }}
       labels:
-        component: {{ .Values.alpha.name }}
         app.kubernetes.io/component: {{ .Values.alpha.name }}
+        component: {{ .Values.alpha.name }}
         {{- include "dgraph.standardLabels" . | nindent 8 }}
         {{- with .Values.alpha.podLabels }}
         {{- toYaml . | nindent 8 }}

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -77,8 +77,8 @@ spec:
         component: {{ .Values.alpha.name }}
         app.kubernetes.io/component: {{ .Values.alpha.name }}
         {{- include "dgraph.standardLabels" . | nindent 8 }}
-        {{- if .Values.alpha.podLabels }}
-{{ .Values.alpha.podLabels | toYaml | indent 8}}
+        {{- with .Values.alpha.podLabels }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
       {{- if .Values.serviceAccount.create }}

--- a/charts/dgraph/templates/alpha/svc-headless.yaml
+++ b/charts/dgraph/templates/alpha/svc-headless.yaml
@@ -4,8 +4,8 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-headless
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    component: {{ .Values.alpha.name }}
     app.kubernetes.io/component: {{ .Values.alpha.name }}
+    component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
     {{- with .Values.alpha.serviceHeadless.labels }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}

--- a/charts/dgraph/templates/alpha/svc-headless.yaml
+++ b/charts/dgraph/templates/alpha/svc-headless.yaml
@@ -4,12 +4,7 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-headless
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.alpha.name }}
-    component: {{ .Values.alpha.name }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
-    {{- with .Values.alpha.serviceHeadless.labels }}
-    {{- toYaml . | trimSuffix "\n" | nindent 4 }}
-    {{- end }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.alpha.name "extra" .Values.alpha.serviceHeadless.labels) | nindent 4 }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/charts/dgraph/templates/alpha/svc-headless.yaml
+++ b/charts/dgraph/templates/alpha/svc-headless.yaml
@@ -10,6 +10,10 @@ metadata:
     {{- with .Values.alpha.serviceHeadless.labels }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
     {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/charts/dgraph/templates/alpha/svc-headless.yaml
+++ b/charts/dgraph/templates/alpha/svc-headless.yaml
@@ -10,10 +10,6 @@ metadata:
     {{- with .Values.alpha.serviceHeadless.labels }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
     {{- end }}
-  {{- with .Values.commonAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/charts/dgraph/templates/alpha/svc-headless.yaml
+++ b/charts/dgraph/templates/alpha/svc-headless.yaml
@@ -4,11 +4,9 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}-headless
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.alpha.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ .Values.alpha.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
     {{- with .Values.alpha.serviceHeadless.labels }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
     {{- end }}

--- a/charts/dgraph/templates/alpha/svc.yaml
+++ b/charts/dgraph/templates/alpha/svc.yaml
@@ -4,9 +4,9 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}
   namespace: {{ include "dgraph.namespace" . }}
   labels:
+    app.kubernetes.io/component: {{ .Values.alpha.name }}
     component: {{ .Values.alpha.name }}
     monitor: {{ .Values.alpha.monitorLabel }}
-    app.kubernetes.io/component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
     {{- with .Values.alpha.service.labels }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}

--- a/charts/dgraph/templates/alpha/svc.yaml
+++ b/charts/dgraph/templates/alpha/svc.yaml
@@ -4,13 +4,9 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.alpha.name }}
-    component: {{ .Values.alpha.name }}
-    monitor: {{ .Values.alpha.monitorLabel }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
-    {{- with .Values.alpha.service.labels }}
-    {{- toYaml . | trimSuffix "\n" | nindent 4 }}
-    {{- end }}
+    {{- $extra := dict "monitor" .Values.alpha.monitorLabel }}
+    {{- with .Values.alpha.service.labels }}{{ $extra = merge $extra . }}{{ end }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.alpha.name "extra" $extra) | nindent 4 }}
   {{- with .Values.alpha.service.annotations }}
   annotations:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}

--- a/charts/dgraph/templates/alpha/svc.yaml
+++ b/charts/dgraph/templates/alpha/svc.yaml
@@ -11,14 +11,9 @@ metadata:
     {{- with .Values.alpha.service.labels }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
     {{- end }}
-  {{- if or .Values.alpha.service.annotations .Values.commonAnnotations }}
+  {{- with .Values.alpha.service.annotations }}
   annotations:
-    {{- with .Values.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- with .Values.alpha.service.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
-    {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.alpha.service.type }}

--- a/charts/dgraph/templates/alpha/svc.yaml
+++ b/charts/dgraph/templates/alpha/svc.yaml
@@ -4,12 +4,10 @@ metadata:
   name: {{ template "dgraph.alpha.fullname" . }}
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.alpha.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
     monitor: {{ .Values.alpha.monitorLabel }}
+    app.kubernetes.io/component: {{ .Values.alpha.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
     {{- with .Values.alpha.service.labels }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
     {{- end }}

--- a/charts/dgraph/templates/alpha/svc.yaml
+++ b/charts/dgraph/templates/alpha/svc.yaml
@@ -11,9 +11,14 @@ metadata:
     {{- with .Values.alpha.service.labels }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
     {{- end }}
-  {{- with .Values.alpha.service.annotations }}
+  {{- if or .Values.alpha.service.annotations .Values.commonAnnotations }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.alpha.service.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.alpha.service.type }}

--- a/charts/dgraph/templates/backups/configs.yaml
+++ b/charts/dgraph/templates/backups/configs.yaml
@@ -8,6 +8,10 @@ metadata:
     component: {{ .Values.backups.name }}
     app.kubernetes.io/component: {{ .Values.backups.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   backup.sh: |
     ######

--- a/charts/dgraph/templates/backups/configs.yaml
+++ b/charts/dgraph/templates/backups/configs.yaml
@@ -5,11 +5,9 @@ metadata:
   name: {{ template "dgraph.backups.fullname" . }}-config
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.backups.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ .Values.backups.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
 data:
   backup.sh: |
     ######

--- a/charts/dgraph/templates/backups/configs.yaml
+++ b/charts/dgraph/templates/backups/configs.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ template "dgraph.backups.fullname" . }}-config
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    component: {{ .Values.backups.name }}
     app.kubernetes.io/component: {{ .Values.backups.name }}
+    component: {{ .Values.backups.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- with .Values.commonAnnotations }}
   annotations:

--- a/charts/dgraph/templates/backups/configs.yaml
+++ b/charts/dgraph/templates/backups/configs.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ template "dgraph.backups.fullname" . }}-config
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.backups.name }}
-    component: {{ .Values.backups.name }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.backups.name) | nindent 4 }}
 data:
   backup.sh: |
     ######

--- a/charts/dgraph/templates/backups/configs.yaml
+++ b/charts/dgraph/templates/backups/configs.yaml
@@ -8,10 +8,6 @@ metadata:
     app.kubernetes.io/component: {{ .Values.backups.name }}
     component: {{ .Values.backups.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- with .Values.commonAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 data:
   backup.sh: |
     ######

--- a/charts/dgraph/templates/backups/cronjob-full.yaml
+++ b/charts/dgraph/templates/backups/cronjob-full.yaml
@@ -21,10 +21,6 @@ metadata:
     app.kubernetes.io/component: {{ .Values.backups.name }}
     component: {{ .Values.backups.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- with .Values.commonAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 spec:
   schedule: "{{ .Values.backups.full.schedule }}"
   jobTemplate:
@@ -41,14 +37,9 @@ spec:
             {{- with .Values.backups.podLabels }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- if or .Values.backups.podAnnotations .Values.commonAnnotations }}
+          {{- with .Values.backups.podAnnotations }}
           annotations:
-            {{- with .Values.commonAnnotations }}
             {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.backups.podAnnotations }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
           {{- end }}
         spec:
           {{- if .Values.serviceAccount.create }}

--- a/charts/dgraph/templates/backups/cronjob-full.yaml
+++ b/charts/dgraph/templates/backups/cronjob-full.yaml
@@ -18,8 +18,8 @@ metadata:
   name: {{ template "dgraph.backups.fullname" . }}-full
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    component: {{ .Values.backups.name }}
     app.kubernetes.io/component: {{ .Values.backups.name }}
+    component: {{ .Values.backups.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- with .Values.commonAnnotations }}
   annotations:
@@ -35,8 +35,8 @@ spec:
       template:
         metadata:
           labels:
-            cronjob: {{ template "dgraph.backups.fullname" . }}-full
             app.kubernetes.io/component: {{ .Values.backups.name }}
+            cronjob: {{ template "dgraph.backups.fullname" . }}-full
             {{- include "dgraph.standardLabels" . | nindent 12 }}
             {{- with .Values.backups.podLabels }}
             {{- toYaml . | nindent 12 }}

--- a/charts/dgraph/templates/backups/cronjob-full.yaml
+++ b/charts/dgraph/templates/backups/cronjob-full.yaml
@@ -18,11 +18,9 @@ metadata:
   name: {{ template "dgraph.backups.fullname" . }}-full
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.backups.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ .Values.backups.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
 spec:
   schedule: "{{ .Values.backups.full.schedule }}"
   jobTemplate:
@@ -34,6 +32,8 @@ spec:
         metadata:
           labels:
             cronjob: {{ template "dgraph.backups.fullname" . }}-full
+            app.kubernetes.io/component: {{ .Values.backups.name }}
+            {{- include "dgraph.standardLabels" . | nindent 12 }}
             {{- if .Values.backups.podLabels }}
 {{ .Values.backups.podLabels | toYaml | indent 12}}
             {{- end }}

--- a/charts/dgraph/templates/backups/cronjob-full.yaml
+++ b/charts/dgraph/templates/backups/cronjob-full.yaml
@@ -21,6 +21,10 @@ metadata:
     component: {{ .Values.backups.name }}
     app.kubernetes.io/component: {{ .Values.backups.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   schedule: "{{ .Values.backups.full.schedule }}"
   jobTemplate:
@@ -37,6 +41,15 @@ spec:
             {{- if .Values.backups.podLabels }}
 {{ .Values.backups.podLabels | toYaml | indent 12}}
             {{- end }}
+          {{- if or .Values.backups.podAnnotations .Values.commonAnnotations }}
+          annotations:
+            {{- with .Values.commonAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.backups.podAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
         spec:
           {{- if .Values.serviceAccount.create }}
           serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/charts/dgraph/templates/backups/cronjob-full.yaml
+++ b/charts/dgraph/templates/backups/cronjob-full.yaml
@@ -114,7 +114,7 @@ spec:
               value: /dgraph/tls/client.{{ .Values.backups.admin.tls_client }}.key
             {{- end }}
             {{- end }}
-          restartPolicy: {{ .Values.backups.incremental.restartPolicy }}
+          restartPolicy: {{ .Values.backups.full.restartPolicy }}
           volumes:
           - name: backup-config-volume
             configMap:

--- a/charts/dgraph/templates/backups/cronjob-full.yaml
+++ b/charts/dgraph/templates/backups/cronjob-full.yaml
@@ -38,9 +38,6 @@ spec:
             cronjob: {{ template "dgraph.backups.fullname" . }}-full
             app.kubernetes.io/component: {{ .Values.backups.name }}
             {{- include "dgraph.standardLabels" . | nindent 12 }}
-            {{- with .Values.cronJobPodLabels }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
             {{- if .Values.backups.podLabels }}
 {{ .Values.backups.podLabels | toYaml | indent 12}}
             {{- end }}

--- a/charts/dgraph/templates/backups/cronjob-full.yaml
+++ b/charts/dgraph/templates/backups/cronjob-full.yaml
@@ -18,9 +18,7 @@ metadata:
   name: {{ template "dgraph.backups.fullname" . }}-full
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.backups.name }}
-    component: {{ .Values.backups.name }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.backups.name) | nindent 4 }}
 spec:
   schedule: "{{ .Values.backups.full.schedule }}"
   jobTemplate:
@@ -31,12 +29,8 @@ spec:
       template:
         metadata:
           labels:
-            app.kubernetes.io/component: {{ .Values.backups.name }}
-            cronjob: {{ template "dgraph.backups.fullname" . }}-full
-            {{- include "dgraph.standardLabels" . | nindent 12 }}
-            {{- with .Values.backups.podLabels }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
+            {{- $extra := dict "cronjob" (printf "%s-full" (include "dgraph.backups.fullname" .)) }}
+            {{- include "dgraph.labels" (dict "ctx" . "component" .Values.backups.name "extra" $extra "podLabels" .Values.backups.podLabels) | nindent 12 }}
           {{- with .Values.backups.podAnnotations }}
           annotations:
             {{- toYaml . | nindent 12 }}

--- a/charts/dgraph/templates/backups/cronjob-full.yaml
+++ b/charts/dgraph/templates/backups/cronjob-full.yaml
@@ -38,8 +38,8 @@ spec:
             cronjob: {{ template "dgraph.backups.fullname" . }}-full
             app.kubernetes.io/component: {{ .Values.backups.name }}
             {{- include "dgraph.standardLabels" . | nindent 12 }}
-            {{- if .Values.backups.podLabels }}
-{{ .Values.backups.podLabels | toYaml | indent 12}}
+            {{- with .Values.backups.podLabels }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- if or .Values.backups.podAnnotations .Values.commonAnnotations }}
           annotations:

--- a/charts/dgraph/templates/backups/cronjob-full.yaml
+++ b/charts/dgraph/templates/backups/cronjob-full.yaml
@@ -24,7 +24,7 @@ spec:
   jobTemplate:
     metadata:
       labels:
-        cronjob: {{ template "dgraph.backups.fullname" . }}-full
+        {{- include "dgraph.labels" (dict "ctx" . "component" .Values.backups.name "extra" (dict "cronjob" (printf "%s-full" (include "dgraph.backups.fullname" .)))) | nindent 8 }}
     spec:
       template:
         metadata:

--- a/charts/dgraph/templates/backups/cronjob-full.yaml
+++ b/charts/dgraph/templates/backups/cronjob-full.yaml
@@ -38,6 +38,9 @@ spec:
             cronjob: {{ template "dgraph.backups.fullname" . }}-full
             app.kubernetes.io/component: {{ .Values.backups.name }}
             {{- include "dgraph.standardLabels" . | nindent 12 }}
+            {{- with .Values.cronJobPodLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- if .Values.backups.podLabels }}
 {{ .Values.backups.podLabels | toYaml | indent 12}}
             {{- end }}

--- a/charts/dgraph/templates/backups/cronjob-inc.yaml
+++ b/charts/dgraph/templates/backups/cronjob-inc.yaml
@@ -18,11 +18,9 @@ metadata:
   name: {{ template "dgraph.backups.fullname" . }}-inc
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.backups.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ .Values.backups.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
 spec:
   schedule: "{{ .Values.backups.incremental.schedule }}"
   jobTemplate:
@@ -34,6 +32,8 @@ spec:
         metadata:
           labels:
             cronjob: {{ template "dgraph.backups.fullname" . }}-inc
+            app.kubernetes.io/component: {{ .Values.backups.name }}
+            {{- include "dgraph.standardLabels" . | nindent 12 }}
             {{- if .Values.backups.podLabels }}
 {{ .Values.backups.podLabels | toYaml | indent 12}}
             {{- end }}

--- a/charts/dgraph/templates/backups/cronjob-inc.yaml
+++ b/charts/dgraph/templates/backups/cronjob-inc.yaml
@@ -18,8 +18,8 @@ metadata:
   name: {{ template "dgraph.backups.fullname" . }}-inc
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    component: {{ .Values.backups.name }}
     app.kubernetes.io/component: {{ .Values.backups.name }}
+    component: {{ .Values.backups.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- with .Values.commonAnnotations }}
   annotations:
@@ -35,8 +35,8 @@ spec:
       template:
         metadata:
           labels:
-            cronjob: {{ template "dgraph.backups.fullname" . }}-inc
             app.kubernetes.io/component: {{ .Values.backups.name }}
+            cronjob: {{ template "dgraph.backups.fullname" . }}-inc
             {{- include "dgraph.standardLabels" . | nindent 12 }}
             {{- with .Values.backups.podLabels }}
             {{- toYaml . | nindent 12 }}

--- a/charts/dgraph/templates/backups/cronjob-inc.yaml
+++ b/charts/dgraph/templates/backups/cronjob-inc.yaml
@@ -21,10 +21,6 @@ metadata:
     app.kubernetes.io/component: {{ .Values.backups.name }}
     component: {{ .Values.backups.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- with .Values.commonAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 spec:
   schedule: "{{ .Values.backups.incremental.schedule }}"
   jobTemplate:
@@ -41,14 +37,9 @@ spec:
             {{- with .Values.backups.podLabels }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- if or .Values.backups.podAnnotations .Values.commonAnnotations }}
+          {{- with .Values.backups.podAnnotations }}
           annotations:
-            {{- with .Values.commonAnnotations }}
             {{- toYaml . | nindent 12 }}
-            {{- end }}
-            {{- with .Values.backups.podAnnotations }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
           {{- end }}
         spec:
           {{- if .Values.serviceAccount.create }}

--- a/charts/dgraph/templates/backups/cronjob-inc.yaml
+++ b/charts/dgraph/templates/backups/cronjob-inc.yaml
@@ -38,6 +38,9 @@ spec:
             cronjob: {{ template "dgraph.backups.fullname" . }}-inc
             app.kubernetes.io/component: {{ .Values.backups.name }}
             {{- include "dgraph.standardLabels" . | nindent 12 }}
+            {{- with .Values.cronJobPodLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- if .Values.backups.podLabels }}
 {{ .Values.backups.podLabels | toYaml | indent 12}}
             {{- end }}

--- a/charts/dgraph/templates/backups/cronjob-inc.yaml
+++ b/charts/dgraph/templates/backups/cronjob-inc.yaml
@@ -38,9 +38,6 @@ spec:
             cronjob: {{ template "dgraph.backups.fullname" . }}-inc
             app.kubernetes.io/component: {{ .Values.backups.name }}
             {{- include "dgraph.standardLabels" . | nindent 12 }}
-            {{- with .Values.cronJobPodLabels }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
             {{- if .Values.backups.podLabels }}
 {{ .Values.backups.podLabels | toYaml | indent 12}}
             {{- end }}

--- a/charts/dgraph/templates/backups/cronjob-inc.yaml
+++ b/charts/dgraph/templates/backups/cronjob-inc.yaml
@@ -38,8 +38,8 @@ spec:
             cronjob: {{ template "dgraph.backups.fullname" . }}-inc
             app.kubernetes.io/component: {{ .Values.backups.name }}
             {{- include "dgraph.standardLabels" . | nindent 12 }}
-            {{- if .Values.backups.podLabels }}
-{{ .Values.backups.podLabels | toYaml | indent 12}}
+            {{- with .Values.backups.podLabels }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- if or .Values.backups.podAnnotations .Values.commonAnnotations }}
           annotations:

--- a/charts/dgraph/templates/backups/cronjob-inc.yaml
+++ b/charts/dgraph/templates/backups/cronjob-inc.yaml
@@ -18,9 +18,7 @@ metadata:
   name: {{ template "dgraph.backups.fullname" . }}-inc
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.backups.name }}
-    component: {{ .Values.backups.name }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.backups.name) | nindent 4 }}
 spec:
   schedule: "{{ .Values.backups.incremental.schedule }}"
   jobTemplate:
@@ -31,12 +29,8 @@ spec:
       template:
         metadata:
           labels:
-            app.kubernetes.io/component: {{ .Values.backups.name }}
-            cronjob: {{ template "dgraph.backups.fullname" . }}-inc
-            {{- include "dgraph.standardLabels" . | nindent 12 }}
-            {{- with .Values.backups.podLabels }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
+            {{- $extra := dict "cronjob" (printf "%s-inc" (include "dgraph.backups.fullname" .)) }}
+            {{- include "dgraph.labels" (dict "ctx" . "component" .Values.backups.name "extra" $extra "podLabels" .Values.backups.podLabels) | nindent 12 }}
           {{- with .Values.backups.podAnnotations }}
           annotations:
             {{- toYaml . | nindent 12 }}

--- a/charts/dgraph/templates/backups/cronjob-inc.yaml
+++ b/charts/dgraph/templates/backups/cronjob-inc.yaml
@@ -24,7 +24,7 @@ spec:
   jobTemplate:
     metadata:
       labels:
-        cronjob: {{ template "dgraph.backups.fullname" . }}-inc
+        {{- include "dgraph.labels" (dict "ctx" . "component" .Values.backups.name "extra" (dict "cronjob" (printf "%s-inc" (include "dgraph.backups.fullname" .)))) | nindent 8 }}
     spec:
       template:
         metadata:

--- a/charts/dgraph/templates/backups/cronjob-inc.yaml
+++ b/charts/dgraph/templates/backups/cronjob-inc.yaml
@@ -21,6 +21,10 @@ metadata:
     component: {{ .Values.backups.name }}
     app.kubernetes.io/component: {{ .Values.backups.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   schedule: "{{ .Values.backups.incremental.schedule }}"
   jobTemplate:
@@ -37,6 +41,15 @@ spec:
             {{- if .Values.backups.podLabels }}
 {{ .Values.backups.podLabels | toYaml | indent 12}}
             {{- end }}
+          {{- if or .Values.backups.podAnnotations .Values.commonAnnotations }}
+          annotations:
+            {{- with .Values.commonAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.backups.podAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
         spec:
           {{- if .Values.serviceAccount.create }}
           serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/charts/dgraph/templates/backups/pv.yaml
+++ b/charts/dgraph/templates/backups/pv.yaml
@@ -8,10 +8,6 @@ metadata:
     app.kubernetes.io/component: {{ .Values.backups.name }}
     component: {{ .Values.backups.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- with .Values.commonAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 spec:
   capacity:
     storage: {{ .Values.backups.nfs.storage }}

--- a/charts/dgraph/templates/backups/pv.yaml
+++ b/charts/dgraph/templates/backups/pv.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ template "dgraph.backups.fullname" . }}-fileserver
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    component: {{ .Values.backups.name }}
     app.kubernetes.io/component: {{ .Values.backups.name }}
+    component: {{ .Values.backups.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- with .Values.commonAnnotations }}
   annotations:

--- a/charts/dgraph/templates/backups/pv.yaml
+++ b/charts/dgraph/templates/backups/pv.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ template "dgraph.backups.fullname" . }}-fileserver
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.backups.name }}
-    component: {{ .Values.backups.name }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.backups.name) | nindent 4 }}
 spec:
   capacity:
     storage: {{ .Values.backups.nfs.storage }}

--- a/charts/dgraph/templates/backups/pv.yaml
+++ b/charts/dgraph/templates/backups/pv.yaml
@@ -5,11 +5,9 @@ metadata:
   name: {{ template "dgraph.backups.fullname" . }}-fileserver
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.backups.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ .Values.backups.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
 spec:
   capacity:
     storage: {{ .Values.backups.nfs.storage }}

--- a/charts/dgraph/templates/backups/pv.yaml
+++ b/charts/dgraph/templates/backups/pv.yaml
@@ -8,6 +8,10 @@ metadata:
     component: {{ .Values.backups.name }}
     app.kubernetes.io/component: {{ .Values.backups.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   capacity:
     storage: {{ .Values.backups.nfs.storage }}

--- a/charts/dgraph/templates/backups/pvc.yaml
+++ b/charts/dgraph/templates/backups/pvc.yaml
@@ -8,10 +8,6 @@ metadata:
     app.kubernetes.io/component: {{ .Values.backups.name }}
     component: {{ .Values.backups.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- with .Values.commonAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 spec:
   accessModes:
     - ReadWriteMany

--- a/charts/dgraph/templates/backups/pvc.yaml
+++ b/charts/dgraph/templates/backups/pvc.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ template "dgraph.backups.fullname" . }}-claim
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    component: {{ .Values.backups.name }}
     app.kubernetes.io/component: {{ .Values.backups.name }}
+    component: {{ .Values.backups.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- with .Values.commonAnnotations }}
   annotations:

--- a/charts/dgraph/templates/backups/pvc.yaml
+++ b/charts/dgraph/templates/backups/pvc.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ template "dgraph.backups.fullname" . }}-claim
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.backups.name }}
-    component: {{ .Values.backups.name }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.backups.name) | nindent 4 }}
 spec:
   accessModes:
     - ReadWriteMany

--- a/charts/dgraph/templates/backups/pvc.yaml
+++ b/charts/dgraph/templates/backups/pvc.yaml
@@ -8,6 +8,10 @@ metadata:
     component: {{ .Values.backups.name }}
     app.kubernetes.io/component: {{ .Values.backups.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   accessModes:
     - ReadWriteMany

--- a/charts/dgraph/templates/backups/pvc.yaml
+++ b/charts/dgraph/templates/backups/pvc.yaml
@@ -5,11 +5,9 @@ metadata:
   name: {{ template "dgraph.backups.fullname" . }}-claim
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.backups.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ .Values.backups.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
 spec:
   accessModes:
     - ReadWriteMany

--- a/charts/dgraph/templates/backups/secrets.yaml
+++ b/charts/dgraph/templates/backups/secrets.yaml
@@ -16,7 +16,7 @@ metadata:
 type: Opaque
 data:
   {{- if .Values.alpha.acl.enabled }}
-  backup_admin_password: {{ .Values.backups.admin.password | toString | b64enc | quote }}
+  backup_admin_password: {{ required "backups.admin.password must be set when alpha.acl.enabled is true and backups are enabled" .Values.backups.admin.password | toString | b64enc | quote }}
   {{- end }}
   {{- if .Values.backups.admin.auth_token }}
   backup_auth_token: {{ .Values.backups.admin.auth_token | toString | b64enc | quote }}

--- a/charts/dgraph/templates/backups/secrets.yaml
+++ b/charts/dgraph/templates/backups/secrets.yaml
@@ -8,11 +8,9 @@ metadata:
   name: {{ template "dgraph.backups.fullname" . }}-secret
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.backups.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ .Values.backups.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- with .Values.alpha.tls.annotations }}
   annotations:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}

--- a/charts/dgraph/templates/backups/secrets.yaml
+++ b/charts/dgraph/templates/backups/secrets.yaml
@@ -11,9 +11,14 @@ metadata:
     component: {{ .Values.backups.name }}
     app.kubernetes.io/component: {{ .Values.backups.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- with .Values.alpha.tls.annotations }}
+  {{- if or .Values.alpha.tls.annotations .Values.commonAnnotations }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.alpha.tls.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
+    {{- end }}
   {{- end }}
 type: Opaque
 data:

--- a/charts/dgraph/templates/backups/secrets.yaml
+++ b/charts/dgraph/templates/backups/secrets.yaml
@@ -8,9 +8,7 @@ metadata:
   name: {{ template "dgraph.backups.fullname" . }}-secret
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.backups.name }}
-    component: {{ .Values.backups.name }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.backups.name) | nindent 4 }}
   {{- with .Values.alpha.tls.annotations }}
   annotations:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}

--- a/charts/dgraph/templates/backups/secrets.yaml
+++ b/charts/dgraph/templates/backups/secrets.yaml
@@ -8,8 +8,8 @@ metadata:
   name: {{ template "dgraph.backups.fullname" . }}-secret
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    component: {{ .Values.backups.name }}
     app.kubernetes.io/component: {{ .Values.backups.name }}
+    component: {{ .Values.backups.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- if or .Values.alpha.tls.annotations .Values.commonAnnotations }}
   annotations:

--- a/charts/dgraph/templates/backups/secrets.yaml
+++ b/charts/dgraph/templates/backups/secrets.yaml
@@ -11,14 +11,9 @@ metadata:
     app.kubernetes.io/component: {{ .Values.backups.name }}
     component: {{ .Values.backups.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- if or .Values.alpha.tls.annotations .Values.commonAnnotations }}
+  {{- with .Values.alpha.tls.annotations }}
   annotations:
-    {{- with .Values.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- with .Values.alpha.tls.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
-    {{- end }}
   {{- end }}
 type: Opaque
 data:

--- a/charts/dgraph/templates/global-ingress.yaml
+++ b/charts/dgraph/templates/global-ingress.yaml
@@ -24,8 +24,8 @@ metadata:
   name: {{ template "dgraph.fullname" . }}-ingress
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    component: {{ .Values.alpha.name }}
     app.kubernetes.io/component: {{ .Values.alpha.name }}
+    component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- if or .Values.global.ingress.annotations .Values.commonAnnotations }}
   annotations:
@@ -86,8 +86,8 @@ metadata:
   name: {{ template "dgraph.fullname" . }}-ingress-grpc
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    component: {{ .Values.alpha.name }}
     app.kubernetes.io/component: {{ .Values.alpha.name }}
+    component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- if or .Values.global.ingress_grpc.annotations .Values.commonAnnotations }}
   annotations:

--- a/charts/dgraph/templates/global-ingress.yaml
+++ b/charts/dgraph/templates/global-ingress.yaml
@@ -24,11 +24,9 @@ metadata:
   name: {{ template "dgraph.fullname" . }}-ingress
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.alpha.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ .Values.alpha.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- with .Values.global.ingress.annotations }}
   annotations:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
@@ -83,11 +81,9 @@ metadata:
   name: {{ template "dgraph.fullname" . }}-ingress-grpc
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.alpha.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ .Values.alpha.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- with .Values.global.ingress_grpc.annotations }}
   annotations:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}

--- a/charts/dgraph/templates/global-ingress.yaml
+++ b/charts/dgraph/templates/global-ingress.yaml
@@ -24,9 +24,7 @@ metadata:
   name: {{ template "dgraph.fullname" . }}-ingress
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.alpha.name }}
-    component: {{ .Values.alpha.name }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.alpha.name) | nindent 4 }}
   {{- with .Values.global.ingress.annotations }}
   annotations:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
@@ -81,9 +79,7 @@ metadata:
   name: {{ template "dgraph.fullname" . }}-ingress-grpc
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.alpha.name }}
-    component: {{ .Values.alpha.name }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.alpha.name) | nindent 4 }}
   {{- with .Values.global.ingress_grpc.annotations }}
   annotations:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}

--- a/charts/dgraph/templates/global-ingress.yaml
+++ b/charts/dgraph/templates/global-ingress.yaml
@@ -27,9 +27,14 @@ metadata:
     component: {{ .Values.alpha.name }}
     app.kubernetes.io/component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- with .Values.global.ingress.annotations }}
+  {{- if or .Values.global.ingress.annotations .Values.commonAnnotations }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.global.ingress.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
 {{- if .Values.global.ingress.ingressClassName }}
@@ -84,9 +89,14 @@ metadata:
     component: {{ .Values.alpha.name }}
     app.kubernetes.io/component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- with .Values.global.ingress_grpc.annotations }}
+  {{- if or .Values.global.ingress_grpc.annotations .Values.commonAnnotations }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.global.ingress_grpc.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
 {{- if .Values.global.ingress_grpc.ingressClassName }}

--- a/charts/dgraph/templates/global-ingress.yaml
+++ b/charts/dgraph/templates/global-ingress.yaml
@@ -27,14 +27,9 @@ metadata:
     app.kubernetes.io/component: {{ .Values.alpha.name }}
     component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- if or .Values.global.ingress.annotations .Values.commonAnnotations }}
+  {{- with .Values.global.ingress.annotations }}
   annotations:
-    {{- with .Values.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- with .Values.global.ingress.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
-    {{- end }}
   {{- end }}
 spec:
 {{- if .Values.global.ingress.ingressClassName }}
@@ -89,14 +84,9 @@ metadata:
     app.kubernetes.io/component: {{ .Values.alpha.name }}
     component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- if or .Values.global.ingress_grpc.annotations .Values.commonAnnotations }}
+  {{- with .Values.global.ingress_grpc.annotations }}
   annotations:
-    {{- with .Values.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- with .Values.global.ingress_grpc.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
-    {{- end }}
   {{- end }}
 spec:
 {{- if .Values.global.ingress_grpc.ingressClassName }}

--- a/charts/dgraph/templates/pre-upgrade-statefulset-cleanup.yaml
+++ b/charts/dgraph/templates/pre-upgrade-statefulset-cleanup.yaml
@@ -77,7 +77,7 @@ spec:
     spec:
       serviceAccountName: {{ template "dgraph.fullname" . }}-pre-upgrade
       restartPolicy: Never
-      {{- with .Values.alpha.tolerations }}
+      {{- with .Values.preUpgradeHook.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -92,22 +92,30 @@ spec:
 
               # StatefulSets (Alpha and Zero)
               for STS in {{ template "dgraph.alpha.fullname" . }} {{ template "dgraph.zero.fullname" . }}; do
-                SELECTOR=$(kubectl get statefulset "$STS" -n "$NS" -o jsonpath='{.spec.selector.matchLabels.chart}' 2>/dev/null || true)
-                if [ -n "$SELECTOR" ]; then
-                  echo "StatefulSet $STS has stale 'chart' selector label ($SELECTOR), deleting with --cascade=orphan..."
-                  kubectl delete statefulset "$STS" --cascade=orphan -n "$NS"
+                if kubectl get statefulset "$STS" -n "$NS" > /dev/null 2>&1; then
+                  SELECTOR=$(kubectl get statefulset "$STS" -n "$NS" -o jsonpath='{.spec.selector.matchLabels.chart}')
+                  if [ -n "$SELECTOR" ]; then
+                    echo "StatefulSet $STS has stale 'chart' selector label ($SELECTOR), deleting with --cascade=orphan..."
+                    kubectl delete statefulset "$STS" --cascade=orphan -n "$NS"
+                  else
+                    echo "StatefulSet $STS does not have 'chart' selector label, skipping."
+                  fi
                 else
-                  echo "StatefulSet $STS does not have 'chart' selector label, skipping."
+                  echo "StatefulSet $STS not found, skipping."
                 fi
               done
 
               # Deployments (Ratel)
               for DEPLOY in {{ template "dgraph.ratel.fullname" . }}; do
-                SELECTOR=$(kubectl get deployment "$DEPLOY" -n "$NS" -o jsonpath='{.spec.selector.matchLabels.chart}' 2>/dev/null || true)
-                if [ -n "$SELECTOR" ]; then
-                  echo "Deployment $DEPLOY has stale 'chart' selector label ($SELECTOR), deleting with --cascade=orphan..."
-                  kubectl delete deployment "$DEPLOY" --cascade=orphan -n "$NS"
+                if kubectl get deployment "$DEPLOY" -n "$NS" > /dev/null 2>&1; then
+                  SELECTOR=$(kubectl get deployment "$DEPLOY" -n "$NS" -o jsonpath='{.spec.selector.matchLabels.chart}')
+                  if [ -n "$SELECTOR" ]; then
+                    echo "Deployment $DEPLOY has stale 'chart' selector label ($SELECTOR), deleting with --cascade=orphan..."
+                    kubectl delete deployment "$DEPLOY" --cascade=orphan -n "$NS"
+                  else
+                    echo "Deployment $DEPLOY does not have 'chart' selector label, skipping."
+                  fi
                 else
-                  echo "Deployment $DEPLOY does not have 'chart' selector label, skipping."
+                  echo "Deployment $DEPLOY not found, skipping."
                 fi
               done

--- a/charts/dgraph/templates/pre-upgrade-statefulset-cleanup.yaml
+++ b/charts/dgraph/templates/pre-upgrade-statefulset-cleanup.yaml
@@ -82,6 +82,9 @@ spec:
       name: {{ template "dgraph.fullname" . }}-pre-upgrade
       labels:
         {{- include "dgraph.standardLabels" . | nindent 8 }}
+        {{- with .Values.jobPodLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.preUpgradeHook.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/dgraph/templates/pre-upgrade-statefulset-cleanup.yaml
+++ b/charts/dgraph/templates/pre-upgrade-statefulset-cleanup.yaml
@@ -12,6 +12,9 @@ metadata:
   labels:
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-10"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -24,6 +27,9 @@ metadata:
   labels:
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-10"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -40,6 +46,9 @@ metadata:
   labels:
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-10"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -60,6 +69,9 @@ metadata:
   labels:
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -68,6 +80,20 @@ spec:
   template:
     metadata:
       name: {{ template "dgraph.fullname" . }}-pre-upgrade
+      labels:
+        {{- include "dgraph.standardLabels" . | nindent 8 }}
+        {{- with .Values.preUpgradeHook.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- if or .Values.preUpgradeHook.podAnnotations .Values.commonAnnotations }}
+      annotations:
+        {{- with .Values.commonAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.preUpgradeHook.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
     spec:
       serviceAccountName: {{ template "dgraph.fullname" . }}-pre-upgrade
       restartPolicy: Never

--- a/charts/dgraph/templates/pre-upgrade-statefulset-cleanup.yaml
+++ b/charts/dgraph/templates/pre-upgrade-statefulset-cleanup.yaml
@@ -92,30 +92,22 @@ spec:
 
               # StatefulSets (Alpha and Zero)
               for STS in {{ template "dgraph.alpha.fullname" . }} {{ template "dgraph.zero.fullname" . }}; do
-                if kubectl get statefulset "$STS" -n "$NS" > /dev/null 2>&1; then
-                  SELECTOR=$(kubectl get statefulset "$STS" -n "$NS" -o jsonpath='{.spec.selector.matchLabels.chart}')
-                  if [ -n "$SELECTOR" ]; then
-                    echo "StatefulSet $STS has stale 'chart' selector label ($SELECTOR), deleting with --cascade=orphan..."
-                    kubectl delete statefulset "$STS" --cascade=orphan -n "$NS"
-                  else
-                    echo "StatefulSet $STS does not have 'chart' selector label, skipping."
-                  fi
+                SELECTOR=$(kubectl get statefulset "$STS" -n "$NS" --ignore-not-found -o jsonpath='{.spec.selector.matchLabels.chart}')
+                if [ -n "$SELECTOR" ]; then
+                  echo "StatefulSet $STS has stale 'chart' selector label ($SELECTOR), deleting with --cascade=orphan..."
+                  kubectl delete statefulset "$STS" --cascade=orphan -n "$NS"
                 else
-                  echo "StatefulSet $STS not found, skipping."
+                  echo "StatefulSet $STS does not have 'chart' selector label (or does not exist), skipping."
                 fi
               done
 
               # Deployments (Ratel)
               for DEPLOY in {{ template "dgraph.ratel.fullname" . }}; do
-                if kubectl get deployment "$DEPLOY" -n "$NS" > /dev/null 2>&1; then
-                  SELECTOR=$(kubectl get deployment "$DEPLOY" -n "$NS" -o jsonpath='{.spec.selector.matchLabels.chart}')
-                  if [ -n "$SELECTOR" ]; then
-                    echo "Deployment $DEPLOY has stale 'chart' selector label ($SELECTOR), deleting with --cascade=orphan..."
-                    kubectl delete deployment "$DEPLOY" --cascade=orphan -n "$NS"
-                  else
-                    echo "Deployment $DEPLOY does not have 'chart' selector label, skipping."
-                  fi
+                SELECTOR=$(kubectl get deployment "$DEPLOY" -n "$NS" --ignore-not-found -o jsonpath='{.spec.selector.matchLabels.chart}')
+                if [ -n "$SELECTOR" ]; then
+                  echo "Deployment $DEPLOY has stale 'chart' selector label ($SELECTOR), deleting with --cascade=orphan..."
+                  kubectl delete deployment "$DEPLOY" --cascade=orphan -n "$NS"
                 else
-                  echo "Deployment $DEPLOY not found, skipping."
+                  echo "Deployment $DEPLOY does not have 'chart' selector label (or does not exist), skipping."
                 fi
               done

--- a/charts/dgraph/templates/pre-upgrade-statefulset-cleanup.yaml
+++ b/charts/dgraph/templates/pre-upgrade-statefulset-cleanup.yaml
@@ -77,16 +77,16 @@ spec:
       {{- end }}
       containers:
         - name: pre-upgrade
-          image: bitnami/kubectl:latest
+          image: {{ .Values.preUpgradeHook.image.registry }}/{{ .Values.preUpgradeHook.image.repository }}:{{ .Values.preUpgradeHook.image.tag }}
           command:
             - /bin/sh
-            - -c
+            - -ec
             - |
               NS="{{ include "dgraph.namespace" . }}"
 
               # StatefulSets (Alpha and Zero)
               for STS in {{ template "dgraph.alpha.fullname" . }} {{ template "dgraph.zero.fullname" . }}; do
-                SELECTOR=$(kubectl get statefulset "$STS" -n "$NS" -o jsonpath='{.spec.selector.matchLabels.chart}' 2>/dev/null)
+                SELECTOR=$(kubectl get statefulset "$STS" -n "$NS" -o jsonpath='{.spec.selector.matchLabels.chart}' 2>/dev/null || true)
                 if [ -n "$SELECTOR" ]; then
                   echo "StatefulSet $STS has stale 'chart' selector label ($SELECTOR), deleting with --cascade=orphan..."
                   kubectl delete statefulset "$STS" --cascade=orphan -n "$NS"
@@ -97,7 +97,7 @@ spec:
 
               # Deployments (Ratel)
               for DEPLOY in {{ template "dgraph.ratel.fullname" . }}; do
-                SELECTOR=$(kubectl get deployment "$DEPLOY" -n "$NS" -o jsonpath='{.spec.selector.matchLabels.chart}' 2>/dev/null)
+                SELECTOR=$(kubectl get deployment "$DEPLOY" -n "$NS" -o jsonpath='{.spec.selector.matchLabels.chart}' 2>/dev/null || true)
                 if [ -n "$SELECTOR" ]; then
                   echo "Deployment $DEPLOY has stale 'chart' selector label ($SELECTOR), deleting with --cascade=orphan..."
                   kubectl delete deployment "$DEPLOY" --cascade=orphan -n "$NS"

--- a/charts/dgraph/templates/pre-upgrade-statefulset-cleanup.yaml
+++ b/charts/dgraph/templates/pre-upgrade-statefulset-cleanup.yaml
@@ -10,7 +10,7 @@ metadata:
   name: {{ template "dgraph.fullname" . }}-pre-upgrade
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" .) | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-10"
@@ -22,7 +22,7 @@ metadata:
   name: {{ template "dgraph.fullname" . }}-pre-upgrade
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" .) | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-10"
@@ -38,7 +38,7 @@ metadata:
   name: {{ template "dgraph.fullname" . }}-pre-upgrade
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" .) | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-10"
@@ -58,7 +58,7 @@ metadata:
   name: {{ template "dgraph.fullname" . }}-pre-upgrade
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" .) | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "0"
@@ -69,10 +69,7 @@ spec:
     metadata:
       name: {{ template "dgraph.fullname" . }}-pre-upgrade
       labels:
-        {{- include "dgraph.standardLabels" . | nindent 8 }}
-        {{- with .Values.preUpgradeHook.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "dgraph.labels" (dict "ctx" . "podLabels" .Values.preUpgradeHook.podLabels) | nindent 8 }}
       {{- with .Values.preUpgradeHook.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/dgraph/templates/pre-upgrade-statefulset-cleanup.yaml
+++ b/charts/dgraph/templates/pre-upgrade-statefulset-cleanup.yaml
@@ -10,10 +10,7 @@ metadata:
   name: {{ template "dgraph.fullname" . }}-pre-upgrade
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-10"
@@ -25,10 +22,7 @@ metadata:
   name: {{ template "dgraph.fullname" . }}-pre-upgrade
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-10"
@@ -44,10 +38,7 @@ metadata:
   name: {{ template "dgraph.fullname" . }}-pre-upgrade
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-10"
@@ -67,10 +58,7 @@ metadata:
   name: {{ template "dgraph.fullname" . }}-pre-upgrade
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "0"

--- a/charts/dgraph/templates/pre-upgrade-statefulset-cleanup.yaml
+++ b/charts/dgraph/templates/pre-upgrade-statefulset-cleanup.yaml
@@ -77,7 +77,7 @@ spec:
     spec:
       serviceAccountName: {{ template "dgraph.fullname" . }}-pre-upgrade
       restartPolicy: Never
-      {{- with .Values.preUpgradeHook.tolerations }}
+      {{- with .Values.alpha.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/dgraph/templates/pre-upgrade-statefulset-cleanup.yaml
+++ b/charts/dgraph/templates/pre-upgrade-statefulset-cleanup.yaml
@@ -12,9 +12,6 @@ metadata:
   labels:
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   annotations:
-    {{- with .Values.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-10"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -27,9 +24,6 @@ metadata:
   labels:
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   annotations:
-    {{- with .Values.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-10"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -46,9 +40,6 @@ metadata:
   labels:
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   annotations:
-    {{- with .Values.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-10"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -69,9 +60,6 @@ metadata:
   labels:
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   annotations:
-    {{- with .Values.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -85,14 +73,9 @@ spec:
         {{- with .Values.preUpgradeHook.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- if or .Values.preUpgradeHook.podAnnotations .Values.commonAnnotations }}
+      {{- with .Values.preUpgradeHook.podAnnotations }}
       annotations:
-        {{- with .Values.commonAnnotations }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- with .Values.preUpgradeHook.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
       {{- end }}
     spec:
       serviceAccountName: {{ template "dgraph.fullname" . }}-pre-upgrade

--- a/charts/dgraph/templates/pre-upgrade-statefulset-cleanup.yaml
+++ b/charts/dgraph/templates/pre-upgrade-statefulset-cleanup.yaml
@@ -82,9 +82,6 @@ spec:
       name: {{ template "dgraph.fullname" . }}-pre-upgrade
       labels:
         {{- include "dgraph.standardLabels" . | nindent 8 }}
-        {{- with .Values.jobPodLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
         {{- with .Values.preUpgradeHook.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/dgraph/templates/ratel/deployment.yaml
+++ b/charts/dgraph/templates/ratel/deployment.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ template "dgraph.ratel.fullname" . }}
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    component: {{ .Values.ratel.name }}
     app.kubernetes.io/component: {{ .Values.ratel.name }}
+    component: {{ .Values.ratel.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- with .Values.commonAnnotations }}
   annotations:
@@ -31,8 +31,8 @@ spec:
         {{- end }}
       {{- end }}
       labels:
-        component: {{ .Values.ratel.name }}
         app.kubernetes.io/component: {{ .Values.ratel.name }}
+        component: {{ .Values.ratel.name }}
         {{- include "dgraph.standardLabels" . | nindent 8 }}
         {{- with .Values.ratel.podLabels }}
         {{- toYaml . | nindent 8 }}

--- a/charts/dgraph/templates/ratel/deployment.yaml
+++ b/charts/dgraph/templates/ratel/deployment.yaml
@@ -34,9 +34,6 @@ spec:
         component: {{ .Values.ratel.name }}
         app.kubernetes.io/component: {{ .Values.ratel.name }}
         {{- include "dgraph.standardLabels" . | nindent 8 }}
-        {{- with .Values.deploymentPodLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
         {{- if .Values.ratel.podLabels }}
 {{ .Values.ratel.podLabels | toYaml | indent 8}}
         {{- end }}

--- a/charts/dgraph/templates/ratel/deployment.yaml
+++ b/charts/dgraph/templates/ratel/deployment.yaml
@@ -8,10 +8,6 @@ metadata:
     app.kubernetes.io/component: {{ .Values.ratel.name }}
     component: {{ .Values.ratel.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- with .Values.commonAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -21,11 +17,8 @@ spec:
   replicas: {{ .Values.ratel.replicaCount }}
   template:
     metadata:
-      {{- if or .Values.ratel.extraAnnotations .Values.commonAnnotations }}
+      {{- if .Values.ratel.extraAnnotations }}
       annotations:
-        {{- with .Values.commonAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
         {{- with .Values.ratel.extraAnnotations }}
 {{- toYaml . | trimSuffix "\n" | nindent 8 }}
         {{- end }}

--- a/charts/dgraph/templates/ratel/deployment.yaml
+++ b/charts/dgraph/templates/ratel/deployment.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ template "dgraph.ratel.fullname" . }}
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.ratel.name }}
-    component: {{ .Values.ratel.name }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.ratel.name) | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -24,12 +22,7 @@ spec:
         {{- end }}
       {{- end }}
       labels:
-        app.kubernetes.io/component: {{ .Values.ratel.name }}
-        component: {{ .Values.ratel.name }}
-        {{- include "dgraph.standardLabels" . | nindent 8 }}
-        {{- with .Values.ratel.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "dgraph.labels" (dict "ctx" . "component" .Values.ratel.name "podLabels" .Values.ratel.podLabels) | nindent 8 }}
     spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/charts/dgraph/templates/ratel/deployment.yaml
+++ b/charts/dgraph/templates/ratel/deployment.yaml
@@ -34,6 +34,9 @@ spec:
         component: {{ .Values.ratel.name }}
         app.kubernetes.io/component: {{ .Values.ratel.name }}
         {{- include "dgraph.standardLabels" . | nindent 8 }}
+        {{- with .Values.deploymentPodLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- if .Values.ratel.podLabels }}
 {{ .Values.ratel.podLabels | toYaml | indent 8}}
         {{- end }}

--- a/charts/dgraph/templates/ratel/deployment.yaml
+++ b/charts/dgraph/templates/ratel/deployment.yaml
@@ -5,11 +5,9 @@ metadata:
   name: {{ template "dgraph.ratel.fullname" . }}
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.ratel.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ .Values.ratel.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -26,10 +24,9 @@ spec:
         {{- end }}
       {{- end }}
       labels:
-        app: {{ template "dgraph.name" . }}
-        chart: {{ template "dgraph.chart" . }}
         component: {{ .Values.ratel.name }}
-        release: {{ .Release.Name }}
+        app.kubernetes.io/component: {{ .Values.ratel.name }}
+        {{- include "dgraph.standardLabels" . | nindent 8 }}
         {{- if .Values.ratel.podLabels }}
 {{ .Values.ratel.podLabels | toYaml | indent 8}}
         {{- end }}

--- a/charts/dgraph/templates/ratel/deployment.yaml
+++ b/charts/dgraph/templates/ratel/deployment.yaml
@@ -34,8 +34,8 @@ spec:
         component: {{ .Values.ratel.name }}
         app.kubernetes.io/component: {{ .Values.ratel.name }}
         {{- include "dgraph.standardLabels" . | nindent 8 }}
-        {{- if .Values.ratel.podLabels }}
-{{ .Values.ratel.podLabels | toYaml | indent 8}}
+        {{- with .Values.ratel.podLabels }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
       {{- if .Values.serviceAccount.create }}

--- a/charts/dgraph/templates/ratel/deployment.yaml
+++ b/charts/dgraph/templates/ratel/deployment.yaml
@@ -8,6 +8,10 @@ metadata:
     component: {{ .Values.ratel.name }}
     app.kubernetes.io/component: {{ .Values.ratel.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -17,8 +21,11 @@ spec:
   replicas: {{ .Values.ratel.replicaCount }}
   template:
     metadata:
-      {{- if .Values.ratel.extraAnnotations }}
+      {{- if or .Values.ratel.extraAnnotations .Values.commonAnnotations }}
       annotations:
+        {{- with .Values.commonAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.ratel.extraAnnotations }}
 {{- toYaml . | trimSuffix "\n" | nindent 8 }}
         {{- end }}

--- a/charts/dgraph/templates/ratel/ingress.yaml
+++ b/charts/dgraph/templates/ratel/ingress.yaml
@@ -24,8 +24,8 @@ metadata:
   name: {{ template "dgraph.ratel.fullname" . }}-ingress
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    component: {{ .Values.ratel.name }}
     app.kubernetes.io/component: {{ .Values.ratel.name }}
+    component: {{ .Values.ratel.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- if or .Values.ratel.ingress.annotations .Values.commonAnnotations }}
   annotations:

--- a/charts/dgraph/templates/ratel/ingress.yaml
+++ b/charts/dgraph/templates/ratel/ingress.yaml
@@ -27,9 +27,14 @@ metadata:
     component: {{ .Values.ratel.name }}
     app.kubernetes.io/component: {{ .Values.ratel.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- with .Values.ratel.ingress.annotations }}
+  {{- if or .Values.ratel.ingress.annotations .Values.commonAnnotations }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.ratel.ingress.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
 {{- if .Values.ratel.ingress.ingressClassName }}

--- a/charts/dgraph/templates/ratel/ingress.yaml
+++ b/charts/dgraph/templates/ratel/ingress.yaml
@@ -24,11 +24,9 @@ metadata:
   name: {{ template "dgraph.ratel.fullname" . }}-ingress
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.ratel.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ .Values.ratel.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- with .Values.ratel.ingress.annotations }}
   annotations:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}

--- a/charts/dgraph/templates/ratel/ingress.yaml
+++ b/charts/dgraph/templates/ratel/ingress.yaml
@@ -27,14 +27,9 @@ metadata:
     app.kubernetes.io/component: {{ .Values.ratel.name }}
     component: {{ .Values.ratel.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- if or .Values.ratel.ingress.annotations .Values.commonAnnotations }}
+  {{- with .Values.ratel.ingress.annotations }}
   annotations:
-    {{- with .Values.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- with .Values.ratel.ingress.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
-    {{- end }}
   {{- end }}
 spec:
 {{- if .Values.ratel.ingress.ingressClassName }}

--- a/charts/dgraph/templates/ratel/ingress.yaml
+++ b/charts/dgraph/templates/ratel/ingress.yaml
@@ -24,9 +24,7 @@ metadata:
   name: {{ template "dgraph.ratel.fullname" . }}-ingress
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.ratel.name }}
-    component: {{ .Values.ratel.name }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.ratel.name) | nindent 4 }}
   {{- with .Values.ratel.ingress.annotations }}
   annotations:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}

--- a/charts/dgraph/templates/ratel/svc.yaml
+++ b/charts/dgraph/templates/ratel/svc.yaml
@@ -5,11 +5,9 @@ metadata:
   name: {{ template "dgraph.ratel.fullname" . }}
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.ratel.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ .Values.ratel.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
     {{- with .Values.ratel.service.labels }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
     {{- end }}

--- a/charts/dgraph/templates/ratel/svc.yaml
+++ b/charts/dgraph/templates/ratel/svc.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ template "dgraph.ratel.fullname" . }}
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    component: {{ .Values.ratel.name }}
     app.kubernetes.io/component: {{ .Values.ratel.name }}
+    component: {{ .Values.ratel.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
     {{- with .Values.ratel.service.labels }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}

--- a/charts/dgraph/templates/ratel/svc.yaml
+++ b/charts/dgraph/templates/ratel/svc.yaml
@@ -11,14 +11,9 @@ metadata:
     {{- with .Values.ratel.service.labels }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
     {{- end }}
-  {{- if or .Values.ratel.service.annotations .Values.commonAnnotations }}
+  {{- with .Values.ratel.service.annotations }}
   annotations:
-    {{- with .Values.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- with .Values.ratel.service.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
-    {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.ratel.service.type }}

--- a/charts/dgraph/templates/ratel/svc.yaml
+++ b/charts/dgraph/templates/ratel/svc.yaml
@@ -11,9 +11,14 @@ metadata:
     {{- with .Values.ratel.service.labels }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
     {{- end }}
-  {{- with .Values.ratel.service.annotations }}
+  {{- if or .Values.ratel.service.annotations .Values.commonAnnotations }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.ratel.service.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.ratel.service.type }}

--- a/charts/dgraph/templates/ratel/svc.yaml
+++ b/charts/dgraph/templates/ratel/svc.yaml
@@ -5,12 +5,7 @@ metadata:
   name: {{ template "dgraph.ratel.fullname" . }}
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.ratel.name }}
-    component: {{ .Values.ratel.name }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
-    {{- with .Values.ratel.service.labels }}
-    {{- toYaml . | trimSuffix "\n" | nindent 4 }}
-    {{- end }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.ratel.name "extra" .Values.ratel.service.labels) | nindent 4 }}
   {{- with .Values.ratel.service.annotations }}
   annotations:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}

--- a/charts/dgraph/templates/serviceaccount.yaml
+++ b/charts/dgraph/templates/serviceaccount.yaml
@@ -6,8 +6,8 @@ metadata:
   name: {{ template "dgraph.serviceAccountName" . }}
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    component: {{ .Values.alpha.name }}
     app.kubernetes.io/component: {{ .Values.alpha.name }}
+    component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
   annotations:

--- a/charts/dgraph/templates/serviceaccount.yaml
+++ b/charts/dgraph/templates/serviceaccount.yaml
@@ -9,13 +9,8 @@ metadata:
     app.kubernetes.io/component: {{ .Values.alpha.name }}
     component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- with .Values.serviceAccount.annotations }}
   annotations:
-    {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- with .Values.serviceAccount.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/dgraph/templates/serviceaccount.yaml
+++ b/charts/dgraph/templates/serviceaccount.yaml
@@ -6,11 +6,9 @@ metadata:
   name: {{ template "dgraph.serviceAccountName" . }}
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.alpha.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ .Values.alpha.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/dgraph/templates/serviceaccount.yaml
+++ b/charts/dgraph/templates/serviceaccount.yaml
@@ -9,8 +9,13 @@ metadata:
     component: {{ .Values.alpha.name }}
     app.kubernetes.io/component: {{ .Values.alpha.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
   annotations:
+    {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/dgraph/templates/serviceaccount.yaml
+++ b/charts/dgraph/templates/serviceaccount.yaml
@@ -6,9 +6,7 @@ metadata:
   name: {{ template "dgraph.serviceAccountName" . }}
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.alpha.name }}
-    component: {{ .Values.alpha.name }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.alpha.name) | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/dgraph/templates/serviceaccount.yaml
+++ b/charts/dgraph/templates/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ template "dgraph.serviceAccountName" . }}
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.alpha.name) | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" .) | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/dgraph/templates/zero/configs.yaml
+++ b/charts/dgraph/templates/zero/configs.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ template "dgraph.zero.fullname" . }}-config
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.zero.name }}
-    component: {{ .Values.zero.name }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.zero.name) | nindent 4 }}
 data:
   {{- with .Values.zero.configFile }}
     {{- toYaml . | trimSuffix "\n" | nindent 2 }}

--- a/charts/dgraph/templates/zero/configs.yaml
+++ b/charts/dgraph/templates/zero/configs.yaml
@@ -8,10 +8,6 @@ metadata:
     app.kubernetes.io/component: {{ .Values.zero.name }}
     component: {{ .Values.zero.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- with .Values.commonAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 data:
   {{- with .Values.zero.configFile }}
     {{- toYaml . | trimSuffix "\n" | nindent 2 }}

--- a/charts/dgraph/templates/zero/configs.yaml
+++ b/charts/dgraph/templates/zero/configs.yaml
@@ -8,6 +8,10 @@ metadata:
     component: {{ .Values.zero.name }}
     app.kubernetes.io/component: {{ .Values.zero.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   {{- with .Values.zero.configFile }}
     {{- toYaml . | trimSuffix "\n" | nindent 2 }}

--- a/charts/dgraph/templates/zero/configs.yaml
+++ b/charts/dgraph/templates/zero/configs.yaml
@@ -5,11 +5,9 @@ metadata:
   name: {{ template "dgraph.zero.fullname" . }}-config
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.zero.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ .Values.zero.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
 data:
   {{- with .Values.zero.configFile }}
     {{- toYaml . | trimSuffix "\n" | nindent 2 }}

--- a/charts/dgraph/templates/zero/configs.yaml
+++ b/charts/dgraph/templates/zero/configs.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ template "dgraph.zero.fullname" . }}-config
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    component: {{ .Values.zero.name }}
     app.kubernetes.io/component: {{ .Values.zero.name }}
+    component: {{ .Values.zero.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- with .Values.commonAnnotations }}
   annotations:

--- a/charts/dgraph/templates/zero/secret-tls.yaml
+++ b/charts/dgraph/templates/zero/secret-tls.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ template "dgraph.zero.fullname" . }}-tls-secret
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    component: {{ .Values.zero.name }}
     app.kubernetes.io/component: {{ .Values.zero.name }}
+    component: {{ .Values.zero.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- if or .Values.zero.tls.annotations .Values.commonAnnotations }}
   annotations:

--- a/charts/dgraph/templates/zero/secret-tls.yaml
+++ b/charts/dgraph/templates/zero/secret-tls.yaml
@@ -8,14 +8,9 @@ metadata:
     app.kubernetes.io/component: {{ .Values.zero.name }}
     component: {{ .Values.zero.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- if or .Values.zero.tls.annotations .Values.commonAnnotations }}
+  {{- with .Values.zero.tls.annotations }}
   annotations:
-    {{- with .Values.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- with .Values.zero.tls.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
-    {{- end }}
   {{- end }}
 type: Opaque
 data:

--- a/charts/dgraph/templates/zero/secret-tls.yaml
+++ b/charts/dgraph/templates/zero/secret-tls.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ template "dgraph.zero.fullname" . }}-tls-secret
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.zero.name }}
-    component: {{ .Values.zero.name }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.zero.name) | nindent 4 }}
   {{- with .Values.zero.tls.annotations }}
   annotations:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}

--- a/charts/dgraph/templates/zero/secret-tls.yaml
+++ b/charts/dgraph/templates/zero/secret-tls.yaml
@@ -5,11 +5,9 @@ metadata:
   name: {{ template "dgraph.zero.fullname" . }}-tls-secret
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.zero.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ .Values.zero.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- with .Values.zero.tls.annotations }}
   annotations:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}

--- a/charts/dgraph/templates/zero/secret-tls.yaml
+++ b/charts/dgraph/templates/zero/secret-tls.yaml
@@ -8,9 +8,14 @@ metadata:
     component: {{ .Values.zero.name }}
     app.kubernetes.io/component: {{ .Values.zero.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- with .Values.zero.tls.annotations }}
+  {{- if or .Values.zero.tls.annotations .Values.commonAnnotations }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.zero.tls.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
+    {{- end }}
   {{- end }}
 type: Opaque
 data:

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -70,9 +70,6 @@ spec:
         component: {{ .Values.zero.name }}
         app.kubernetes.io/component: {{ .Values.zero.name }}
         {{- include "dgraph.standardLabels" . | nindent 8 }}
-        {{- with .Values.statefulSetPodLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
         {{- if .Values.zero.podLabels }}
 {{ .Values.zero.podLabels | toYaml | indent 8}}
         {{- end }}

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -25,8 +25,8 @@ metadata:
   name: "{{ template "dgraph.zero.fullname" . }}"
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    component: {{ .Values.zero.name }}
     app.kubernetes.io/component: {{ .Values.zero.name }}
+    component: {{ .Values.zero.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
   {{- with .Values.commonAnnotations }}
   annotations:
@@ -67,8 +67,8 @@ spec:
         {{- end }}
       {{- end }}
       labels:
-        component: {{ .Values.zero.name }}
         app.kubernetes.io/component: {{ .Values.zero.name }}
+        component: {{ .Values.zero.name }}
         {{- include "dgraph.standardLabels" . | nindent 8 }}
         {{- with .Values.zero.podLabels }}
         {{- toYaml . | nindent 8 }}

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -28,10 +28,6 @@ metadata:
     app.kubernetes.io/component: {{ .Values.zero.name }}
     component: {{ .Values.zero.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
-  {{- with .Values.commonAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 spec:
   serviceName: {{ template "dgraph.zero.fullname" . }}-headless
   replicas: {{ .Values.zero.replicaCount }}
@@ -52,11 +48,8 @@ spec:
   template:
     metadata:
       name: {{ template "dgraph.zero.fullname" . }}
-      {{- if or .Values.zero.metrics.enabled .Values.zero.extraAnnotations .Values.commonAnnotations }}
+      {{- if or .Values.zero.metrics.enabled .Values.zero.extraAnnotations }}
       annotations:
-        {{- with .Values.commonAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
         {{- if .Values.zero.metrics.enabled }}
         prometheus.io/path: /debug/prometheus_metrics
         prometheus.io/port: "6080"

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -70,8 +70,8 @@ spec:
         component: {{ .Values.zero.name }}
         app.kubernetes.io/component: {{ .Values.zero.name }}
         {{- include "dgraph.standardLabels" . | nindent 8 }}
-        {{- if .Values.zero.podLabels }}
-{{ .Values.zero.podLabels | toYaml | indent 8}}
+        {{- with .Values.zero.podLabels }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
       {{- if .Values.serviceAccount.create }}

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -28,6 +28,10 @@ metadata:
     component: {{ .Values.zero.name }}
     app.kubernetes.io/component: {{ .Values.zero.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   serviceName: {{ template "dgraph.zero.fullname" . }}-headless
   replicas: {{ .Values.zero.replicaCount }}
@@ -48,8 +52,11 @@ spec:
   template:
     metadata:
       name: {{ template "dgraph.zero.fullname" . }}
-      {{- if or .Values.zero.metrics.enabled .Values.zero.extraAnnotations }}
+      {{- if or .Values.zero.metrics.enabled .Values.zero.extraAnnotations .Values.commonAnnotations }}
       annotations:
+        {{- with .Values.commonAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- if .Values.zero.metrics.enabled }}
         prometheus.io/path: /debug/prometheus_metrics
         prometheus.io/port: "6080"

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -25,9 +25,7 @@ metadata:
   name: "{{ template "dgraph.zero.fullname" . }}"
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.zero.name }}
-    component: {{ .Values.zero.name }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.zero.name) | nindent 4 }}
 spec:
   serviceName: {{ template "dgraph.zero.fullname" . }}-headless
   replicas: {{ .Values.zero.replicaCount }}
@@ -60,12 +58,7 @@ spec:
         {{- end }}
       {{- end }}
       labels:
-        app.kubernetes.io/component: {{ .Values.zero.name }}
-        component: {{ .Values.zero.name }}
-        {{- include "dgraph.standardLabels" . | nindent 8 }}
-        {{- with .Values.zero.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- include "dgraph.labels" (dict "ctx" . "component" .Values.zero.name "podLabels" .Values.zero.podLabels) | nindent 8 }}
     spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -70,6 +70,9 @@ spec:
         component: {{ .Values.zero.name }}
         app.kubernetes.io/component: {{ .Values.zero.name }}
         {{- include "dgraph.standardLabels" . | nindent 8 }}
+        {{- with .Values.statefulSetPodLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- if .Values.zero.podLabels }}
 {{ .Values.zero.podLabels | toYaml | indent 8}}
         {{- end }}

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -25,11 +25,9 @@ metadata:
   name: "{{ template "dgraph.zero.fullname" . }}"
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.zero.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ .Values.zero.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
 spec:
   serviceName: {{ template "dgraph.zero.fullname" . }}-headless
   replicas: {{ .Values.zero.replicaCount }}
@@ -62,10 +60,9 @@ spec:
         {{- end }}
       {{- end }}
       labels:
-        app: {{ template "dgraph.name" . }}
-        chart: {{ template "dgraph.chart" . }}
-        release: {{ .Release.Name }}
         component: {{ .Values.zero.name }}
+        app.kubernetes.io/component: {{ .Values.zero.name }}
+        {{- include "dgraph.standardLabels" . | nindent 8 }}
         {{- if .Values.zero.podLabels }}
 {{ .Values.zero.podLabels | toYaml | indent 8}}
         {{- end }}

--- a/charts/dgraph/templates/zero/svc-headless.yaml
+++ b/charts/dgraph/templates/zero/svc-headless.yaml
@@ -10,6 +10,10 @@ metadata:
     {{- with .Values.zero.serviceHeadless.labels }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
     {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/charts/dgraph/templates/zero/svc-headless.yaml
+++ b/charts/dgraph/templates/zero/svc-headless.yaml
@@ -4,11 +4,9 @@ metadata:
   name: {{ template "dgraph.zero.fullname" . }}-headless
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.zero.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: {{ .Values.zero.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
     {{- with .Values.zero.serviceHeadless.labels }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
     {{- end }}

--- a/charts/dgraph/templates/zero/svc-headless.yaml
+++ b/charts/dgraph/templates/zero/svc-headless.yaml
@@ -4,8 +4,8 @@ metadata:
   name: {{ template "dgraph.zero.fullname" . }}-headless
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    component: {{ .Values.zero.name }}
     app.kubernetes.io/component: {{ .Values.zero.name }}
+    component: {{ .Values.zero.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
     {{- with .Values.zero.serviceHeadless.labels }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}

--- a/charts/dgraph/templates/zero/svc-headless.yaml
+++ b/charts/dgraph/templates/zero/svc-headless.yaml
@@ -10,10 +10,6 @@ metadata:
     {{- with .Values.zero.serviceHeadless.labels }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
     {{- end }}
-  {{- with .Values.commonAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/charts/dgraph/templates/zero/svc-headless.yaml
+++ b/charts/dgraph/templates/zero/svc-headless.yaml
@@ -4,12 +4,7 @@ metadata:
   name: {{ template "dgraph.zero.fullname" . }}-headless
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.zero.name }}
-    component: {{ .Values.zero.name }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
-    {{- with .Values.zero.serviceHeadless.labels }}
-    {{- toYaml . | trimSuffix "\n" | nindent 4 }}
-    {{- end }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.zero.name "extra" .Values.zero.serviceHeadless.labels) | nindent 4 }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/charts/dgraph/templates/zero/svc.yaml
+++ b/charts/dgraph/templates/zero/svc.yaml
@@ -4,12 +4,10 @@ metadata:
   name: {{ template "dgraph.zero.fullname" . }}
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app: {{ template "dgraph.name" . }}
-    chart: {{ template "dgraph.chart" . }}
     component: {{ .Values.zero.name }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
     monitor: {{ .Values.zero.monitorLabel }}
+    app.kubernetes.io/component: {{ .Values.zero.name }}
+    {{- include "dgraph.standardLabels" . | nindent 4 }}
     {{- with .Values.zero.service.labels }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
     {{- end }}

--- a/charts/dgraph/templates/zero/svc.yaml
+++ b/charts/dgraph/templates/zero/svc.yaml
@@ -11,9 +11,14 @@ metadata:
     {{- with .Values.zero.service.labels }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
     {{- end }}
-  {{- with .Values.zero.service.annotations }}
+  {{- if or .Values.zero.service.annotations .Values.commonAnnotations }}
   annotations:
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.zero.service.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.zero.service.type }}

--- a/charts/dgraph/templates/zero/svc.yaml
+++ b/charts/dgraph/templates/zero/svc.yaml
@@ -11,14 +11,9 @@ metadata:
     {{- with .Values.zero.service.labels }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
     {{- end }}
-  {{- if or .Values.zero.service.annotations .Values.commonAnnotations }}
+  {{- with .Values.zero.service.annotations }}
   annotations:
-    {{- with .Values.commonAnnotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- with .Values.zero.service.annotations }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}
-    {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.zero.service.type }}

--- a/charts/dgraph/templates/zero/svc.yaml
+++ b/charts/dgraph/templates/zero/svc.yaml
@@ -4,13 +4,9 @@ metadata:
   name: {{ template "dgraph.zero.fullname" . }}
   namespace: {{ include "dgraph.namespace" . }}
   labels:
-    app.kubernetes.io/component: {{ .Values.zero.name }}
-    component: {{ .Values.zero.name }}
-    monitor: {{ .Values.zero.monitorLabel }}
-    {{- include "dgraph.standardLabels" . | nindent 4 }}
-    {{- with .Values.zero.service.labels }}
-    {{- toYaml . | trimSuffix "\n" | nindent 4 }}
-    {{- end }}
+    {{- $extra := dict "monitor" .Values.zero.monitorLabel }}
+    {{- with .Values.zero.service.labels }}{{ $extra = merge $extra . }}{{ end }}
+    {{- include "dgraph.labels" (dict "ctx" . "component" .Values.zero.name "extra" $extra) | nindent 4 }}
   {{- with .Values.zero.service.annotations }}
   annotations:
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}

--- a/charts/dgraph/templates/zero/svc.yaml
+++ b/charts/dgraph/templates/zero/svc.yaml
@@ -4,9 +4,9 @@ metadata:
   name: {{ template "dgraph.zero.fullname" . }}
   namespace: {{ include "dgraph.namespace" . }}
   labels:
+    app.kubernetes.io/component: {{ .Values.zero.name }}
     component: {{ .Values.zero.name }}
     monitor: {{ .Values.zero.monitorLabel }}
-    app.kubernetes.io/component: {{ .Values.zero.name }}
     {{- include "dgraph.standardLabels" . | nindent 4 }}
     {{- with .Values.zero.service.labels }}
     {{- toYaml . | trimSuffix "\n" | nindent 4 }}

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -7,6 +7,11 @@
 #   imagePullSecrets:
 #     - myRegistryKeySecretName
 
+## Labels to add to all resources
+commonLabels: {}
+## Annotations to add to all resources
+commonAnnotations: {}
+
 image: &image
   registry: docker.io
   repository: dgraph/dgraph
@@ -33,6 +38,8 @@ preUpgradeHook:
     registry: docker.io
     repository: bitnami/kubectl
     tag: "1.31"
+  podLabels: {}
+  podAnnotations: {}
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -623,6 +630,8 @@ backups:
   # schedulerName: stork
   ## CronJob spec.jobTemplate.spec.template.metadata.labels
   podLabels: {}
+  ## CronJob spec.jobTemplate.spec.template.metadata.annotations
+  podAnnotations: {}
   admin:
     ## backup user and password that is a member of 'guardians'group used to
     ## login if ACLs are enabled.  This fetches an access token used to trigger backups

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -9,8 +9,6 @@
 
 ## Labels to add to all resources
 commonLabels: {}
-## Annotations to add to all resources
-commonAnnotations: {}
 
 image: &image
   registry: docker.io

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -12,12 +12,6 @@ commonLabels: {}
 ## Annotations to add to all resources
 commonAnnotations: {}
 
-## Pod labels applied to pods by workload type (additive with commonLabels and per-component podLabels)
-statefulSetPodLabels: {}
-deploymentPodLabels: {}
-cronJobPodLabels: {}
-jobPodLabels: {}
-
 image: &image
   registry: docker.io
   repository: dgraph/dgraph

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -40,7 +40,6 @@ preUpgradeHook:
   ## Note: annotations with boolean-looking values (e.g. "false") should be
   ## set via --set-string or a values file to avoid YAML type coercion.
   podAnnotations: {}
-  tolerations: []
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -7,7 +7,9 @@
 #   imagePullSecrets:
 #     - myRegistryKeySecretName
 
-## Labels to add to all resources
+## Labels to add to all resources and pod templates.
+## These have the lowest priority — chart-defined labels (like monitorLabel)
+## and per-component podLabels will override commonLabels on key conflicts.
 commonLabels: {}
 
 image: &image
@@ -64,6 +66,8 @@ zero:
   ## StatefulSet spec.template.metadata.labels
   podLabels: {}
 
+  ## Value for the "monitor" label on the zero Service (not on pods or other resources).
+  ## Used by Prometheus for service discovery.
   monitorLabel: zero-dgraph-io
   ## StatefulSet controller supports automated updates. There are two valid update strategies: RollingUpdate and OnDelete
   ## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets
@@ -251,6 +255,8 @@ alpha:
   ## StatefulSet spec.template.metadata.labels
   podLabels: {}
 
+  ## Value for the "monitor" label on the alpha Service (not on pods or other resources).
+  ## Used by Prometheus for service discovery.
   monitorLabel: alpha-dgraph-io
   ## StatefulSet controller supports automated updates. There are two valid update strategies: RollingUpdate and OnDelete
   ## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -33,6 +33,9 @@ image: &image
   ##
   debug: false
 
+## Pre-upgrade hook Job that handles v24-to-v25 StatefulSet selector migration.
+## Runs automatically on helm upgrade — detects and recreates StatefulSets
+## with stale selector labels using --cascade=orphan to avoid downtime.
 preUpgradeHook:
   image:
     registry: docker.io

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -124,7 +124,7 @@ zero:
   extraFlags: ""
 
   ## Configuration file for dgraph zero used as an alternative to command-line options
-  ## Ref: https://dgraph.io/docs/deploy/config/
+  ## Ref: https://docs.dgraph.io/cli/config
   configFile: {}
 
   # automatically mount a ServiceAccount API credentials
@@ -312,7 +312,7 @@ alpha:
   extraFlags: ""
 
   ## Configuration file for dgraph alpha used as an alternative to command-line options
-  ## Ref: https://dgraph.io/docs/deploy/config/
+  ## Ref: https://docs.dgraph.io/cli/config
   configFile: {}
 
   # automatically mount a ServiceAccount API credentials
@@ -376,7 +376,7 @@ alpha:
 
   ## TLS Configuration
   ## Documentation on dgraph alpha TLS options,
-  ##  see https://dgraph.io/docs/deploy/security/tls-configuration/#tls-options
+  ##  see https://docs.dgraph.io/admin/security/tls-configuration#tls-options
   tls:
     enabled: false
     ## Files created from './tls' directory set with `dgraph cert` command
@@ -479,7 +479,7 @@ alpha:
   ## Examples can include:
   ## * offline data restore from binary backups with `dgraph restore`
   ##   (ref. https://docs.dgraph.io/admin/admin-tasks/binary-backups#online-restore)
-  ## * bulk loader (ref. https://dgraph.io/docs/howto/importdata/bulk-loader/)
+  ## * bulk loader (ref. https://docs.dgraph.io/migration/bulk-loader)
   initContainers:
     init:
       enabled: false
@@ -644,12 +644,12 @@ backups:
     # password: password
     ## Mutual TLS client certificate and key can be used to secure transaction that was created with
     ## dgraph cert --client <name-of-client> should be specified here.
-    ## ref. https://dgraph.io/docs/deploy/security/tls-configuration/#tls-options
+    ## ref. https://docs.dgraph.io/admin/security/tls-configuration#tls-options
     tls_client: ""
     ## Authorization Token can be used to secure /login and /admin.  The auth token
     ## string that is set Alpha configuration or environment variable needs to be
     ## specified here so that backups can properly login.
-    ## ref. https://dgraph.io/docs/deploy/admin/dgraph-administration/#secure-alter-operations
+    ## ref. https://docs.dgraph.io/admin/security/admin-endpoint-security#securing-alter-operations
     auth_token: ""
   ## Backups image - image needs at least curl command
   ## default is to reuse dgraph image

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -384,7 +384,7 @@ alpha:
     files: {}
 
   ## ACL Configuration
-  ## ref: https://dgraph.io/docs/access-control-lists/
+  ## ref: https://docs.dgraph.io/installation/configuration/enable-acl
   acl:
     enabled: false
     ## The values in `file: {}` will be the filename as key and the file data as the value.
@@ -395,7 +395,7 @@ alpha:
     #   hmac_secret_file: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMQo=
 
   ## Encryption at Rest Configuration
-  ## ref: https://dgraph.io/docs/encryption-at-rest/
+  ## ref: https://docs.dgraph.io/installation/configuration/encryption-at-rest
   encryption:
     enabled: false
     ## The values in `file: {}` will be the filename as key and the file data as the value.
@@ -478,7 +478,7 @@ alpha:
   ## You may want to initialize the Alphas with data before starting Alpha containers.
   ## Examples can include:
   ## * offline data restore from binary backups with `dgraph restore`
-  ##   (ref. https://dgraph.io/docs/binary-backups/#restore-from-backup)
+  ##   (ref. https://docs.dgraph.io/admin/admin-tasks/binary-backups#online-restore)
   ## * bulk loader (ref. https://dgraph.io/docs/howto/importdata/bulk-loader/)
   initContainers:
     init:
@@ -624,7 +624,7 @@ ratel:
   customReadinessProbe: {}
 
 ## Binary Backup CronJob Configuration
-## ref: https://dgraph.io/docs/binary-backups/
+## ref: https://docs.dgraph.io/admin/admin-tasks/binary-backups
 ##
 backups:
   name: backups
@@ -639,7 +639,7 @@ backups:
   admin:
     ## backup user and password that is a member of 'guardians'group used to
     ## login if ACLs are enabled.  This fetches an access token used to trigger backups
-    ## ref: https://dgraph.io/docs/access-control-lists/
+    ## ref: https://docs.dgraph.io/installation/configuration/enable-acl
     user: groot
     # password: password
     ## Mutual TLS client certificate and key can be used to secure transaction that was created with

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -28,6 +28,12 @@ image: &image
   ##
   debug: false
 
+preUpgradeHook:
+  image:
+    registry: docker.io
+    repository: bitnami/kubectl
+    tag: "1.31"
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -37,7 +37,10 @@ preUpgradeHook:
     repository: bitnami/kubectl
     tag: "1.31"
   podLabels: {}
+  ## Note: annotations with boolean-looking values (e.g. "false") should be
+  ## set via --set-string or a values file to avoid YAML type coercion.
   podAnnotations: {}
+  tolerations: []
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -13,7 +13,7 @@ commonLabels: {}
 image: &image
   registry: docker.io
   repository: dgraph/dgraph
-  tag: v25.0.0-preview6
+  tag: v25.3.1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -376,8 +376,7 @@ alpha:
     files: {}
 
   ## ACL Configuration
-  ## Documentation on Enterprise ACL Feature
-  ##  see https://dgraph.io/docs/enterprise-features/access-control-lists/
+  ## ref: https://dgraph.io/docs/access-control-lists/
   acl:
     enabled: false
     ## The values in `file: {}` will be the filename as key and the file data as the value.
@@ -388,8 +387,7 @@ alpha:
     #   hmac_secret_file: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMQo=
 
   ## Encryption at Rest Configuration
-  ## Documentation on Enterprise ACL Feature
-  ##  see https://dgraph.io/docs/enterprise-features/encryption-at-rest/
+  ## ref: https://dgraph.io/docs/encryption-at-rest/
   encryption:
     enabled: false
     ## The values in `file: {}` will be the filename as key and the file data as the value.
@@ -472,7 +470,7 @@ alpha:
   ## You may want to initialize the Alphas with data before starting Alpha containers.
   ## Examples can include:
   ## * offline data restore from binary backups with `dgraph restore`
-  ##   (ref. https://dgraph.io/docs/enterprise-features/binary-backups/#restore-from-backup)
+  ##   (ref. https://dgraph.io/docs/binary-backups/#restore-from-backup)
   ## * bulk loader (ref. https://dgraph.io/docs/howto/importdata/bulk-loader/)
   initContainers:
     init:
@@ -617,8 +615,8 @@ ratel:
   customLivenessProbe: {}
   customReadinessProbe: {}
 
-## Binary Backup CronJob Configuration (Enterprise feature)
-## ref: https://dgraph.io/docs/enterprise-features/binary-backups/
+## Binary Backup CronJob Configuration
+## ref: https://dgraph.io/docs/binary-backups/
 ##
 backups:
   name: backups
@@ -633,7 +631,7 @@ backups:
   admin:
     ## backup user and password that is a member of 'guardians'group used to
     ## login if ACLs are enabled.  This fetches an access token used to trigger backups
-    ## ref: https://dgraph.io/docs/enterprise-features/access-control-lists/
+    ## ref: https://dgraph.io/docs/access-control-lists/
     user: groot
     # password: password
     ## Mutual TLS client certficate and key can be used to secure transaction that was created with

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -12,6 +12,12 @@ commonLabels: {}
 ## Annotations to add to all resources
 commonAnnotations: {}
 
+## Pod labels applied to pods by workload type (additive with commonLabels and per-component podLabels)
+statefulSetPodLabels: {}
+deploymentPodLabels: {}
+cronJobPodLabels: {}
+jobPodLabels: {}
+
 image: &image
   registry: docker.io
   repository: dgraph/dgraph

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -637,7 +637,7 @@ backups:
     ## ref: https://dgraph.io/docs/access-control-lists/
     user: groot
     # password: password
-    ## Mutual TLS client certficate and key can be used to secure transaction that was created with
+    ## Mutual TLS client certificate and key can be used to secure transaction that was created with
     ## dgraph cert --client <name-of-client> should be specified here.
     ## ref. https://dgraph.io/docs/deploy/security/tls-configuration/#tls-options
     tls_client: ""
@@ -681,7 +681,7 @@ backups:
     ## enable bash debugging (set -x)
     debug: false
     ## incremental backup schedule
-    ## every hour, except 12AM serer time
+    ## every hour, except 12AM server time
     schedule: "0 1-23 * * *"
     ## restart policy
     restartPolicy: Never
@@ -691,7 +691,7 @@ backups:
   ##   s3://s3.us-west-2.amazonaws.com/<bucketname>
   ##   minio://my-release-minio.default.svc:9000/<bucketname>
   destination: *nfs_backups_path
-  ## subpath directory useful to store full and reclated incremental backuups
+  ## subpath directory useful to store full and related incremental backups
   ## in the same directory.
   ## NOTE: It is important to create directory name that matches the schedule.
   ##       For example, daily fulls and hourly incrementals, a directory could

--- a/charts/ratel/README.md
+++ b/charts/ratel/README.md
@@ -9,10 +9,10 @@ helm install "my-ratel" --namespace "my-ratel" dgraph/ratel
 
 ## Introduction
 
-Ratel is a [SPA](https://wikipedia.org/wiki/Single-page_application) ([single-page-application](https://wikipedia.org/wiki/Single-page_application)) [React](https://react.dev/) client that runs locally from your web browser.  The server component is a small web server that hosts the client application, which is then downloaed into your browser locally. There is no server-to-server connection. 
+Ratel is a [SPA](https://wikipedia.org/wiki/Single-page_application) ([single-page-application](https://wikipedia.org/wiki/Single-page_application)) [React](https://react.dev/) client that runs locally from your web browser.  The server component is a small web server that hosts the client application, which is then downloaded into your browser locally. There is no server-to-server connection. 
 
 
-### Prequisites
+### Prerequisites
 
 * Kubernetes 1.20+
 * Helm 3.0+
@@ -22,7 +22,7 @@ Ratel is a [SPA](https://wikipedia.org/wiki/Single-page_application) ([single-pa
 
 For best practices in security, it is recommended that you install Ratel separately instead of bundled together with the Dgraph.  This small web server should be installed in a namespace that is separate from Dgraph server. If your Kubernetes cluster supports the [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) feature, such as [Calico](https://www.tigera.io/project-calico/), you can use these to restrict traffic between the web service hosting Ratel and Dgraph servers.
 
-Given this, use thie helm chart to install Ratel separately from Dgraph
+Given this, use the helm chart to install Ratel separately from Dgraph
 
 ### Accessing Ratel
 


### PR DESCRIPTION
## Summary

- Add `app.kubernetes.io/*` recommended labels (`name`, `instance`, `version`, `component`, `managed-by`) and `helm.sh/chart` to all metadata and pod template label blocks
- Introduce `dgraph.labels` dict-based helper that builds all labels into a Go map and renders via `toYaml` — label keys are always alphabetically sorted by the YAML marshaler, no manual ordering to maintain
- Add `commonLabels` value that propagates custom labels to all resources and pod templates
- Add `backups.podAnnotations` and `preUpgradeHook.podLabels`/`preUpgradeHook.podAnnotations` — fills gaps where pod-level customization was missing (e.g. `sidecar.istio.io/inject: "false"` on Jobs)
- Add standard labels to CronJob `jobTemplate.metadata` (previously only had a bare `cronjob` label)
- Remove misleading `component: alpha` label from the shared ServiceAccount
- Harden pre-upgrade hook: pin kubectl image to `1.31` (was `:latest`), make it configurable via `preUpgradeHook.image` for airgapped environments, add `set -e` for error propagation, and use two-step existence check to avoid silently swallowing RBAC/connectivity errors
- Fix full backup CronJob using `backups.incremental.restartPolicy` instead of `backups.full.restartPolicy`
- Add `required` validation for `backups.admin.password` when ACL is enabled — previously rendered an empty secret silently
- Replace `semverCompare "< 1.2.3 || 20.03.0"` with explicit `or` of two `semverCompare` calls for clarity
- Remove outdated "Enterprise feature" references — all features are open source under Apache 2.0 as of Dgraph v25
- Fix all broken `dgraph.io/docs/` URLs to use `docs.dgraph.io` with correct paths (verified all return 200)
- Fix spelling errors across documentation and templates (including a broken `$RATEL_POD_NAME` variable in NOTES.txt)
- Normalize backup CronJob pod templates to include `component` label (was inconsistently missing)
- Fix `podLabels` indentation to use `nindent` consistently
- Selectors (`matchLabels`) are intentionally unchanged — they remain on the legacy labels (`app`, `release`, `component`) to preserve zero-downtime upgrades from v24 via the existing `--cascade=orphan` pre-upgrade hook

## Breaking changes (v25.3.1-preview2)

- **Full backup restartPolicy**: The full backup CronJob previously read its `restartPolicy` from `backups.incremental.restartPolicy` instead of `backups.full.restartPolicy`. If you worked around this by setting `backups.incremental.restartPolicy` to control the full backup, move that value to `backups.full.restartPolicy`.
- **Backup admin password now required**: When `alpha.acl.enabled` is true and backups are enabled, `backups.admin.password` must be explicitly set. Previously the chart silently rendered an empty secret.

## `dgraph.labels` helper

All labels are built as a dict and rendered via `toYaml`, guaranteeing alphabetical key order. The helper accepts:

| Parameter | Description |
|-----------|-------------|
| `ctx` | Helm root context (required) |
| `component` | Sets both `component` and `app.kubernetes.io/component` (optional) |
| `extra` | Dict of additional chart-defined labels like `monitor` or `cronjob` (optional) |
| `podLabels` | Dict of user-supplied per-component pod labels (optional) |

On key conflicts, higher-priority sources override lower-priority ones:

| Priority | Source | Description |
|----------|--------|-------------|
| Lowest | `commonLabels` | From values.yaml, applied to every resource |
| | `podLabels` | From values.yaml, only passed on pod templates |
| | `extra` | Chart-defined, only passed by specific templates |
| | `component` | Chart-defined, omitted on shared resources |
| Highest | Standard labels | `app`, `chart`, `release`, `heritage`, `app.kubernetes.io/*` |

## New values

| Value | Default | Description |
|-------|---------|-------------|
| `commonLabels` | `{}` | Labels added to all resources and pod templates |
| `backups.podAnnotations` | `{}` | Annotations for backup CronJob pods |
| `preUpgradeHook.image.registry` | `docker.io` | Pre-upgrade hook image registry |
| `preUpgradeHook.image.repository` | `bitnami/kubectl` | Pre-upgrade hook image repository |
| `preUpgradeHook.image.tag` | `1.31` | Pre-upgrade hook image tag |
| `preUpgradeHook.podLabels` | `{}` | Labels for pre-upgrade hook Job pods |
| `preUpgradeHook.podAnnotations` | `{}` | Annotations for pre-upgrade hook Job pods |

## Test plan

- `helm lint charts/dgraph` passes
- `helm template` across 11 value permutations produces output identical to the previous text-based approach, with two expected differences:
  - `app.kubernetes.io/version` renders unquoted (`v25.3.1` vs `"v25.3.1"`) — YAML-equivalent, cosmetic only
  - Backup CronJob pods now include `component: backups` (normalizes a pre-existing inconsistency)
- `helm template` with `--set commonLabels.team=platform` confirms label on all resources and pod templates
- `helm template` with `--set commonLabels.app=override` confirms standard labels cannot be overridden
- `helm template` with `--set alpha.podLabels.custom=val` confirms label on alpha pods only
- `helm template` with `--set-string preUpgradeHook.podAnnotations."sidecar\.istio\.io/inject"=false` confirms Istio disable on hook pod
- Selectors remain unchanged (`app`, `release`, `component` only)
- All labels render in alphabetical order
- CronJob `jobTemplate.metadata.labels` now includes full standard labels
- Pre-upgrade hook uses two-step existence check (RBAC errors propagate, "not found" is handled gracefully)
- No "enterprise" references remain outside of `example_values/v20.11/`
- All `docs.dgraph.io` URLs verified to return 200 with correct content

🤖 Generated with Claude Code