### PR TITLE
fix(ratel): correct Ingress rule host placement and example values

### DIFF
--- a/charts/ratel/example_values/ingress/ingress-alb-no_host.yaml
+++ b/charts/ratel/example_values/ingress/ingress-alb-no_host.yaml
@@ -1,8 +1,9 @@
 # aws-load-balancer-controller
 # * https://github.com/kubernetes-sigs/aws-load-balancer-controller
-# NOTE: 
-#  * shared ALB with group name of 'dgraph' will be used.  
+# NOTE:
+#  * shared ALB with group name of 'dgraph' will be used.
 #    This avoids provisioning multiple ALBs
+ingress:
   enabled: true
   className: alb
   annotations:

--- a/charts/ratel/example_values/ingress/ingress-alb-no_host.yaml
+++ b/charts/ratel/example_values/ingress/ingress-alb-no_host.yaml
@@ -14,4 +14,3 @@ ingress:
     - paths:
         - path: /*
           pathType: ImplementationSpecific
-      host: ratel.example.com

--- a/charts/ratel/example_values/ingress/ingress-alb-with_host.yaml
+++ b/charts/ratel/example_values/ingress/ingress-alb-with_host.yaml
@@ -5,6 +5,7 @@ ingress:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
   hosts:
-    - paths:
-        - path: /*
-          pathType: ImplementationSpecific
+    - host: ratel.example.com
+      paths:
+        - path: /
+          pathType: Prefix

--- a/charts/ratel/templates/ingress.yaml
+++ b/charts/ratel/templates/ingress.yaml
@@ -39,7 +39,12 @@ spec:
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
+    {{- if .host }}
+    - host: {{ .host | quote }}
+      http:
+    {{- else }}
     - http:
+    {{- end }}
         paths:
           {{- range .paths }}
           - path: {{ .path }}
@@ -57,8 +62,5 @@ spec:
               servicePort: {{ $svcPort }}
               {{- end }}
           {{- end }}
-        {{- if .host }}
-        host: {{ .host | quote }}
-        {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary

Fixes the standalone Ratel chart Ingress template so `ingress.hosts[].host` is rendered in the correct place in the Kubernetes Ingress rules structure. Also repairs the ALB example values file so it is valid when passed with `helm install -f`.

---

## Problem

`host` was emitted under the `http` block (alongside `paths`), which does not match the Ingress API. Controllers would not apply the hostname as intended, so custom hosts (e.g. behind HAProxy Ingress class) appeared broken even when set in values.

---

## Solution

- Emit each rule as either:
  - `host: ...` + `http: ...`, or
  - `http: ...` only when no host is set
- Keep `paths` unchanged under `http`
- Add the missing top-level `ingress:` key in:
  - `example_values/ingress/ingress-alb-no_host.yaml`