### PR TITLE
ENG 1942/fix unrestricted dgraph admin access

### DIFF
--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -589,7 +589,7 @@ When ACLs are used, the backup cronjob will log in to the Alpha node using a spe
 When a simple Auth Token is used, the backup cronjob script will submit an auth token when requesting a backup.
 
 * Alpha
-  * Alpha will need to be configured with environment variable `DGRAPH_ALPHA_AUTH_TOKEN` or configuration with `auth_token` set.
+  * Alpha will need to be configured with environment variable `DGRAPH_ALPHA_TOKEN` or configuration with `auth_token` set.
 * Backups
   * `backups.admin.auth_token` - this will need to have the same value configured in Alpha
 

--- a/charts/dgraph/templates/backups/cronjob-full.yaml
+++ b/charts/dgraph/templates/backups/cronjob-full.yaml
@@ -87,7 +87,7 @@ spec:
             - name: tls-volume
               mountPath: /dgraph/tls
             {{- end }}
-            {{- if .Values.alpha.acl.enabled }}
+            {{- if or .Values.alpha.acl.enabled .Values.backups.admin.auth_token }}
             - name: backup-secret-volume
               mountPath: /backup_secrets
             {{- end }}
@@ -126,7 +126,7 @@ spec:
             secret:
               secretName: {{ template "dgraph.alpha.fullname" . }}-tls-secret
           {{- end }}
-          {{- if or (.Values.alpha.acl.enabled) (.Values.backups.admin.auth_token) }}
+          {{- if or .Values.alpha.acl.enabled .Values.backups.admin.auth_token }}
           - name: backup-secret-volume
             secret:
               secretName: {{ template "dgraph.backups.fullname" . }}-secret

--- a/charts/dgraph/templates/backups/cronjob-inc.yaml
+++ b/charts/dgraph/templates/backups/cronjob-inc.yaml
@@ -87,7 +87,7 @@ spec:
             - name: tls-volume
               mountPath: /dgraph/tls
             {{- end }}
-            {{- if .Values.alpha.acl.enabled }}
+            {{- if or .Values.alpha.acl.enabled .Values.backups.admin.auth_token }}
             - name: backup-secret-volume
               mountPath: /backup_secrets
             {{- end }}

--- a/charts/dgraph/templates/global-ingress.yaml
+++ b/charts/dgraph/templates/global-ingress.yaml
@@ -50,17 +50,19 @@ spec:
   rules:
     - http:
         paths:
+          {{- range $path := .Values.global.ingress.alpha_paths | default (list "/graphql") }}
           - backend:
               service:
-                name:  {{ template "dgraph.alpha.fullname" . }}
+                name:  {{ template "dgraph.alpha.fullname" $ }}
                 port:
                   number: 8080
             pathType: ImplementationSpecific
-            path: {{ template "path" . }}
+            path: {{ $path }}
+          {{- end }}
       {{- if .Values.global.ingress.alpha_hostname }}
       host: {{ .Values.global.ingress.alpha_hostname }}
       {{- end }}
-    {{- if .Values.ratel.enabled }}
+    {{- if and .Values.ratel.enabled .Values.global.ingress.expose_ratel }}
     - http:
         paths:
           - backend:

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -711,6 +711,15 @@ global:
     tls: {}
     ratel_hostname: null
     alpha_hostname: null
+    ## Paths exposed on the alpha hostname. Defaults to GraphQL only so that
+    ## /admin, etc. are not reachable via the public ingress. In-cluster callers
+    ## continue to reach all paths # via the alpha Service.
+    alpha_paths:
+      - /graphql
+    ## When true, add a rule for the Ratel UI to this ingress. Default is off:
+    ## Ratel exposes admin actions against alpha, so it should not share a
+    ## public ingress unless that ingress has its own auth in front of it.
+    expose_ratel: false
   ingress_grpc:
     enabled: false
     ingressClassName: null


### PR DESCRIPTION
- **ensure backup secrets are mounted when an auth_token is provided**
- **[docs] Fix env variable for configuring security.token**
- **fix: limit default ingress path to /graphql**
