### PR TITLE
Expose priorityClassName for alpha and zero pods

### DIFF
--- a/charts/dgraph/Chart.yaml
+++ b/charts/dgraph/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: dgraph
 type: application
-version: 25.3.1-preview2
+version: 25.3.1-preview3
 appVersion: v25.3.1
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:

--- a/charts/dgraph/README.md
+++ b/charts/dgraph/README.md
@@ -104,6 +104,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `zero.podLabels`                         | Specify additional labels for template metadata                       | `{}`                                                |
 | `zero.updateStrategy`                    | Strategy for upgrading zero nodes                                     | `RollingUpdate`                                     |
 | `zero.schedulerName`                     | Configure an explicit scheduler                                       | `nil`                                               |
+| `zero.priorityClassName`                 | PriorityClass to protect zero pods from preemption                    | `nil`                                               |
 | `zero.monitorLabel`                      | "monitor" label on the zero Service (for Prometheus service discovery) | `zero-dgraph-io`                                    |
 | `zero.rollingUpdatePartition`            | Partition update strategy                                             | `nil`                                               |
 | `zero.podManagementPolicy`               | Pod management policy for zero nodes                                  | `OrderedReady`                                      |
@@ -149,6 +150,7 @@ The following table lists the configurable parameters of the `dgraph` chart and 
 | `alpha.monitorLabel`                     | "monitor" label on the alpha Service (for Prometheus service discovery) | `alpha-dgraph-io`                                   |
 | `alpha.updateStrategy`                   | Strategy for upgrading alpha nodes                                    | `RollingUpdate`                                     |
 | `alpha.schedulerName`                    | Configure an explicit scheduler                                       | `nil`                                               |
+| `alpha.priorityClassName`                | PriorityClass to protect alpha pods from preemption                   | `nil`                                               |
 | `alpha.rollingUpdatePartition`           | Partition update strategy                                             | `nil`                                               |
 | `alpha.podManagementPolicy`              | Pod management policy for alpha nodes                                 | `OrderedReady`                                      |
 | `alpha.replicaCount`                     | Number of alpha nodes                                                 | `3`                                                 |

--- a/charts/dgraph/example_values/default-priority-config.yaml
+++ b/charts/dgraph/example_values/default-priority-config.yaml
@@ -1,0 +1,50 @@
+## Exercises the priorityClassName field on the alpha and zero StatefulSets.
+## The referenced PriorityClass (dgraph-test-high) must exist on the cluster
+## before deploying, otherwise the priority admission controller rejects the pods.
+alpha:
+  priorityClassName: dgraph-test-high
+  configFile:
+    config.yaml: |
+      limit:
+        query_timeout: 5m
+        max_retries: -1
+        mutations: allow
+        normalize_node: 10000
+        query_edge: 1000000
+      alsologtostderr: true
+      badger:
+        compression: snappy
+      bindall: true
+      telemetry:
+        sentry: true
+        reports: true
+      export: export
+      graphql:
+        introspection: true
+      log_backtrace_at: ":0"
+      logtostderr: true
+      ludicrous:
+        enabled: false
+      raft:
+        pending_proposals: 256
+        snapshot_after_entries: 10000
+      port_offset: 0
+      postings: "/dgraph/p"
+      trace:
+        ratio: 0.01
+      wal: "/dgraph/w"
+zero:
+  priorityClassName: dgraph-test-high
+  configFile:
+    config.yaml: |
+      alsologtostderr: true
+      bindall: true
+      telemetry:
+        sentry: true
+        reports: true
+      log_backtrace_at: ":0"
+      logtostderr: true
+      rebalance_interval: 8m0s
+      trace:
+        ratio: 0.01
+      wal: "/dgraph/zw"

--- a/charts/dgraph/templates/alpha/statefulset.yaml
+++ b/charts/dgraph/templates/alpha/statefulset.yaml
@@ -74,6 +74,9 @@ spec:
       {{- if .Values.alpha.schedulerName }}
       schedulerName: {{ .Values.alpha.schedulerName }}
       {{- end }}
+      {{- if .Values.alpha.priorityClassName }}
+      priorityClassName: {{ .Values.alpha.priorityClassName }}
+      {{- end }}
       {{- if or (eq .Values.alpha.antiAffinity "hard") (eq .Values.alpha.antiAffinity "soft") .Values.alpha.nodeAffinity }}
       affinity:
       {{- end }}

--- a/charts/dgraph/templates/zero/statefulset.yaml
+++ b/charts/dgraph/templates/zero/statefulset.yaml
@@ -67,6 +67,9 @@ spec:
       {{- if .Values.zero.schedulerName }}
       schedulerName: {{ .Values.zero.schedulerName }}
       {{- end }}
+      {{- if .Values.zero.priorityClassName }}
+      priorityClassName: {{ .Values.zero.priorityClassName }}
+      {{- end }}
       {{- if or (eq .Values.zero.antiAffinity "hard") (eq .Values.zero.antiAffinity "soft") .Values.zero.nodeAffinity }}
       affinity:
       {{- end }}

--- a/charts/dgraph/tests/alpha_priority_test.yaml
+++ b/charts/dgraph/tests/alpha_priority_test.yaml
@@ -1,0 +1,15 @@
+suite: alpha priorityClassName
+templates:
+  - templates/alpha/statefulset.yaml
+tests:
+  - it: omits priorityClassName when unset (chart defaults)
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName
+  - it: renders priorityClassName when set
+    set:
+      alpha.priorityClassName: high-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: high-priority

--- a/charts/dgraph/tests/zero_priority_test.yaml
+++ b/charts/dgraph/tests/zero_priority_test.yaml
@@ -1,0 +1,15 @@
+suite: zero priorityClassName
+templates:
+  - templates/zero/statefulset.yaml
+tests:
+  - it: omits priorityClassName when unset (chart defaults)
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName
+  - it: renders priorityClassName when set
+    set:
+      zero.priorityClassName: high-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: high-priority

--- a/charts/dgraph/values.yaml
+++ b/charts/dgraph/values.yaml
@@ -82,6 +82,13 @@ zero:
   ##
   # schedulerName: stork
 
+  ## Pod priority
+  ## https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+  ## priorityClassName references an existing PriorityClass to protect pods from
+  ## preemption. Preemption behavior is configured on the PriorityClass itself.
+  ##
+  # priorityClassName: high-priority
+
   ## Partition update strategy
   ## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
   ##
@@ -270,6 +277,13 @@ alpha:
   ## https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
   ##
   # schedulerName: stork
+
+  ## Pod priority
+  ## https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+  ## priorityClassName references an existing PriorityClass to protect pods from
+  ## preemption. Preemption behavior is configured on the PriorityClass itself.
+  ##
+  # priorityClassName: high-priority
 
   ## Partition update strategy
   ## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions

--- a/helmfiles/tests/helmfile.yaml
+++ b/helmfiles/tests/helmfile.yaml
@@ -7,6 +7,7 @@ environments:
   alpha-tls:
   default-json:
   default-yaml:
+  default-priority:
   zero-tls:
 
 releases:


### PR DESCRIPTION
Closes #129.

## Problem

The alpha and zero StatefulSets have no way to reference a PriorityClass, so their pods can't be protected from preemption on contended clusters.

## Solution

Expose an optional `alpha.priorityClassName` and `zero.priorityClassName` (default unset). Pod-level `preemptionPolicy` is intentionally *not* exposed: Kubernetes rejects a pod whose `preemptionPolicy` differs from its PriorityClass, so it belongs on the PriorityClass itself — matching the convention of the Bitnami, Consul, and prometheus charts.

## The details

Adds the chart's first `helm-unittest` suites (`charts/dgraph/tests/`) covering the rendered field, plus a `default-priority` helmfile env + example values for manual live-cluster testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
